### PR TITLE
separated out payment stuff from link stuff into its own paymentRepository

### DIFF
--- a/packages/hypernet-core/src/implementations/HypernetCore.ts
+++ b/packages/hypernet-core/src/implementations/HypernetCore.ts
@@ -30,6 +30,8 @@ import { AccountService, LinkService, PaymentService } from "@implementations/bu
 import { PaymentUtils } from "./utilities";
 import { IPaymentRepository } from "@interfaces/data/IPaymentRepository";
 import { PaymentRepository } from "./data/PaymentRepository";
+import { ILinkUtils } from "@interfaces/utilities/ILinkUtils";
+import { LinkUtils } from "./utilities/LinkUtils";
 
 export class HypernetCore implements IHypernetCore {
   public onControlClaimed: Subject<ControlClaim>;
@@ -45,6 +47,7 @@ export class HypernetCore implements IHypernetCore {
   protected browserNodeProvider: IBrowserNodeProvider;
   protected vectorUtils: IVectorUtils;
   protected paymentUtils: IPaymentUtils;
+  protected linkUtils: ILinkUtils;
 
   protected accountRepository: IAccountsRepository;
   protected linkRepository: ILinkRepository;
@@ -84,6 +87,7 @@ export class HypernetCore implements IHypernetCore {
     this.configProvider = new ConfigProvider(config);
 
     this.paymentUtils = new PaymentUtils(this.configProvider);
+    this.linkUtils = new LinkUtils()
 
     this.contextProvider = new ContextProvider(
       this.onControlClaimed,
@@ -106,7 +110,7 @@ export class HypernetCore implements IHypernetCore {
       this.contextProvider,
       this.vectorUtils,
       this.paymentUtils,
-      this.paymentRepository);
+      this.linkUtils);
 
     this.paymentService = new PaymentService(this.linkRepository, 
       this.accountRepository, 

--- a/packages/hypernet-core/src/implementations/api/VectorAPIListener.ts
+++ b/packages/hypernet-core/src/implementations/api/VectorAPIListener.ts
@@ -33,7 +33,7 @@ export class VectorAPIListener implements IVectorListener {
 
             // If you didn't send this transfer, you want to notify the user
             // that a payment is available for them to accept (insurance, paramterized, etc)
-            const transferType = this.vectorUtils.getTransferType(payload.transfer);
+            const transferType = this.paymentUtils.getTransferType(payload.transfer);
             if (transferType == ETransferType.Offer) {
                 this.paymentService.offerReceived(metadata.paymentId);
             } else if (transferType == ETransferType.Insurance) {

--- a/packages/hypernet-core/src/implementations/business/LinkService.ts
+++ b/packages/hypernet-core/src/implementations/business/LinkService.ts
@@ -6,6 +6,9 @@ import { HypernetLink } from "@interfaces/objects";
 export class LinkService implements ILinkService {
     constructor(protected ledgerRepository: ILinkRepository) {}
     
+    /**
+     * 
+     */
     public async getLedgers(): Promise<HypernetLink[]> {
         return this.ledgerRepository.getHypernetLinks();
     }

--- a/packages/hypernet-core/src/implementations/business/PaymentService.ts
+++ b/packages/hypernet-core/src/implementations/business/PaymentService.ts
@@ -2,15 +2,11 @@ import { IPaymentService } from "@interfaces/business";
 import { IAccountsRepository, ILinkRepository } from "@interfaces/data";
 import { IPaymentRepository } from "@interfaces/data/IPaymentRepository";
 import {
-    HypernetLink,
     BigNumber,
     Payment,
     EthereumAddress,
     PublicKey,
-    ControlClaim,
-    HypernetConfig,
     PublicIdentifier,
-    Balances,
     PushPayment,
     PullPayment
   } from "@interfaces/objects";
@@ -21,13 +17,12 @@ import { IConfigProvider, IContextProvider } from "@interfaces/utilities";
  * PaymentService uses Vector internally to send payments on the requested channel.
  */
 export class PaymentService implements IPaymentService {
-    constructor(protected linkRepository: ILinkRepository,
+    constructor(
+        protected linkRepository: ILinkRepository,
         protected accountRepository: IAccountsRepository,
         protected contextProvider: IContextProvider,
         protected configProvider: IConfigProvider,
-        protected paymentRepository: IPaymentRepository) {
-
-    }
+        protected paymentRepository: IPaymentRepository) {}
 
     /**
      * 
@@ -36,7 +31,7 @@ export class PaymentService implements IPaymentService {
     public async acceptFunds(paymentIds: string[]): Promise<Payment[]> {
         // Get the payments from the repo, to make sure it can be accepted.
         const config = await this.configProvider.getConfig();
-        const payments = await this.paymentRepository.getPaymentsById(paymentIds);
+        const payments = await this.paymentRepository.getPaymentsByIds(paymentIds);
         const hypertokenBalance = await this.accountRepository.getBalanceByAsset(config.hypertokenAddress)
 
         // Loop over the payments and do a sanity check
@@ -68,7 +63,7 @@ export class PaymentService implements IPaymentService {
      * Called by the reciever of a parameterized transfer
      */
     public async paymentPosted(paymentId: string): Promise<void> {
-        const payments = await this.paymentRepository.getPaymentsById([paymentId]);
+        const payments = await this.paymentRepository.getPaymentsByIds([paymentId]);
         const payment = payments.get(paymentId);
 
         if (payment == null || payment.state != EPaymentState.Approved) {
@@ -87,15 +82,23 @@ export class PaymentService implements IPaymentService {
         }
     }
 
+    /**
+     * 
+     * @param paymentId 
+     */
     public async pullRecorded(paymentId: string): Promise<void> {
-        const payments = await this.paymentRepository.getPaymentsById([paymentId]);
+        const payments = await this.paymentRepository.getPaymentsByIds([paymentId]);
         const payment = payments.get(paymentId);
         
         throw new Error('Method not yet implemented')
     }
 
+    /**
+     * 
+     * @param paymentId 
+     */
     public async stakePosted(paymentId: string): Promise<void> {
-        const payments = await this.paymentRepository.getPaymentsById([paymentId]);
+        const payments = await this.paymentRepository.getPaymentsByIds([paymentId]);
         const payment = payments.get(paymentId);
     
         if (payment == null || payment.state != EPaymentState.Staked) {
@@ -115,7 +118,7 @@ export class PaymentService implements IPaymentService {
      */
     public async offerReceived(paymentId: string): Promise<void> {
         
-        const paymentsPromise =  this.paymentRepository.getPaymentsById([paymentId]);
+        const paymentsPromise =  this.paymentRepository.getPaymentsByIds([paymentId]);
         const contextPromise = this.contextProvider.getInitializedContext();
         const [payments, context] = await Promise.all([paymentsPromise, contextPromise])
         

--- a/packages/hypernet-core/src/implementations/data/PaymentRepository.ts
+++ b/packages/hypernet-core/src/implementations/data/PaymentRepository.ts
@@ -1,12 +1,9 @@
 import { IPaymentRepository } from "@interfaces/data/IPaymentRepository";
-import { BigNumber, HypernetConfig, HypernetContext, HypernetLink, IHypernetTransferMetadata, InitializedHypernetContext, Payment, PublicIdentifier, PullAmount, PullPayment, PushPayment } from "@interfaces/objects";
+import { BigNumber, IHypernetTransferMetadata, Payment, PublicIdentifier } from "@interfaces/objects";
 import { IBrowserNodeProvider, IConfigProvider, IContextProvider, IPaymentUtils, IVectorUtils } from "@interfaces/utilities";
-import { FullTransferState, NodeResponses } from "@connext/vector-types";
-import { EPaymentState, EPaymentType, ETransferType } from "@interfaces/types";
-import moment from "moment";
-import { BrowserNode } from "@connext/vector-browser-node";
+import { EPaymentType } from "@interfaces/types";
 import { EthereumAddress, PublicKey } from "@interfaces/objects";
-import { SortedTransfers } from "@implementations/utilities";
+import moment from "moment";
 
 export class PaymentRepository implements IPaymentRepository {
 
@@ -18,6 +15,15 @@ export class PaymentRepository implements IPaymentRepository {
         protected paymentUtils: IPaymentUtils
     ) { }
 
+    /**
+     * 
+     * @param counterPartyAccount 
+     * @param amount 
+     * @param expirationDate 
+     * @param requiredStake 
+     * @param paymentToken 
+     * @param disputeMediator 
+     */
     public async createPushPayment(
         counterPartyAccount: PublicIdentifier,
         amount: BigNumber,
@@ -51,7 +57,8 @@ export class PaymentRepository implements IPaymentRepository {
             } as IHypernetTransferMetadata);
 
         // Return the payment
-        const payment = this.getPaymentByTransfers(paymentId,
+        const payment = this.paymentUtils.transfersToPayment(
+            paymentId,
             [transfer],
             config,
             browserNode);
@@ -59,182 +66,11 @@ export class PaymentRepository implements IPaymentRepository {
         return payment;
     }
 
-    public getPushPaymentByTransfers(id: string,
-        to: PublicIdentifier,
-        from: PublicIdentifier,
-        state: EPaymentState,
-        sortedTransfers: SortedTransfers,
-        metadata: IHypernetTransferMetadata): PushPayment {
-
-        /**
-         * Push payments consist of 3 transfers, a null transfer for 0 value that represents the 
-         * offer, an insurance payment, and a parameterized payment. 
-         */
-
-        if (sortedTransfers.pullRecordTransfers.length > 0) {
-            throw new Error("Push payment has pull transfers!");
-        }
-
-        const amountStaked = sortedTransfers.insuranceTransfer != null ? sortedTransfers.insuranceTransfer.balance.amount[0] : 0;
-
-        return new PushPayment(id,
-            to,
-            from,
-            state,
-            sortedTransfers.offerTransfer.assetId,
-            BigNumber.from(metadata.requiredStake),
-            BigNumber.from(amountStaked),
-            102,
-            false,
-            moment(),
-            moment(),
-            BigNumber.from(0),
-            metadata.disputeMediator,
-            BigNumber.from(metadata.paymentAmount),
-        );
-    }
-
-    public getPullPaymentByTransfers(id: string,
-        to: PublicIdentifier,
-        from: PublicIdentifier,
-        state: EPaymentState,
-        sortedTransfers: SortedTransfers,
-        metadata: IHypernetTransferMetadata): PullPayment {
-            
-        /**
-         * Push payments consist of 3 transfers, a null transfer for 0 value that represents the 
-         * offer, an insurance payment, and a parameterized payment. 
-         */
-
-        if (sortedTransfers.pullRecordTransfers.length > 0) {
-            throw new Error("Push payment has pull transfers!");
-        }
-
-        const amountStaked = sortedTransfers.insuranceTransfer != null ? sortedTransfers.insuranceTransfer.balance.amount[0] : 0;
-
-        return new PullPayment(id,
-            to,
-            from,
-            state,
-            sortedTransfers.offerTransfer.assetId,
-            BigNumber.from(metadata.requiredStake),
-            BigNumber.from(amountStaked),
-            102,
-            false,
-            moment.unix(metadata.creationDate),
-            moment(),
-            BigNumber.from(0),
-            metadata.disputeMediator,
-            BigNumber.from(metadata.paymentAmount),
-            BigNumber.from(0),
-            new Array<PullAmount>()
-        );
-    }
-
-    public async getPaymentByTransfers(
-        fullPaymentId: string,
-        transfers: FullTransferState[],
-        config: HypernetConfig,
-        browserNode: BrowserNode): Promise<Payment> {
-
-        // const signerAddress = getSignerAddressFromPublicIdentifier(context.publicIdentifier);
-
-        let [domain, paymentType, id] = fullPaymentId.split(":");
-        if (domain != config.hypernetProtocolDomain) {
-            throw new Error(`Invalid payment domain: ${domain}`);
-        }
-
-        if (id == "" || id == null) {
-            throw new Error(`Missing id component of paymentId`);
-        }
-
-        const sortedTransfers = await this.vectorUtils.sortTransfers(fullPaymentId, transfers, browserNode);
-
-        // Determine the state of the payment. All transfers we've been given are
-        // "Active", therefore, not resolved. So we don't need to figure out if
-        // the transfer is resolved, we know it's not.
-        // Given that info, the payment state is never going to be Finalized,
-        // because those transfers disappear.
-
-        let paymentState = EPaymentState.Proposed;
-        if (sortedTransfers.insuranceTransfer != null &&
-            sortedTransfers.parameterizedTransfer == null) {
-            paymentState = EPaymentState.Staked;
-        }
-        else if (sortedTransfers.insuranceTransfer != null &&
-            sortedTransfers.parameterizedTransfer != null) {
-            paymentState = EPaymentState.Approved;
-        }
-
-        // TODO: Figure out how to determine if the payment is Disputed
-
-        if (paymentType == EPaymentType.Pull) {
-            return this.getPullPaymentByTransfers(id,
-                sortedTransfers.metadata.to,
-                sortedTransfers.metadata.from,
-                paymentState,
-                sortedTransfers,
-                sortedTransfers.offerTransfer.meta);
-        } else if (paymentType == EPaymentType.Push) {
-            return this.getPushPaymentByTransfers(id,
-                sortedTransfers.metadata.to,
-                sortedTransfers.metadata.from,
-                paymentState,
-                sortedTransfers,
-                sortedTransfers.offerTransfer.meta);
-        } else {
-            throw new Error(`Unknown`)
-        }
-    }
-
     /**
-     * Given an array of Vector transfers, return the corresponding Hypernet Payments
-     * @param transfers 
-     * @param config 
-     * @param context 
-     * @param browserNode 
+     * 
+     * @param paymentIds 
      */
-    public async getPaymentsByTransfers(
-        transfers: FullTransferState[], 
-        config: HypernetConfig,
-        context: InitializedHypernetContext,
-        browserNode: BrowserNode): Promise<Payment[]> {
-
-        // First, we are going to sort the transfers into buckets based on their payment_id
-        let transfersByPaymentId = new Map<string, FullTransferState[]>();
-        for (let transfer of transfers) {
-            const paymentId = transfer.meta.paymentId;
-
-            // Get the existing array of payments. Initialize it if it's not there.
-            let transferArray = transfersByPaymentId.get(paymentId);
-            if (transferArray == undefined) {
-                transferArray = [];
-                transfersByPaymentId.set(paymentId, transferArray);
-            }
-
-            transferArray.push(transfer);
-        }
-
-        // Now we have the transfers sorted by their payment ID.
-        // Loop over them and convert them to proper payments.
-        // This is all async, so we can do the whole thing in parallel.
-        const paymentPromises = new Array<Promise<Payment>>();
-        transfersByPaymentId.forEach(async (transferArray, paymentId) => {
-            const payment = this.getPaymentByTransfers(paymentId,
-                transferArray,
-                config,
-                browserNode);
-
-            paymentPromises.push(payment);
-        });
-        
-        // Convert all the transfers to payments
-        const payments = await Promise.all(paymentPromises);
-
-        return payments;
-    }
-
-    public async getPaymentsById(paymentIds: string[]): Promise<Map<string, Payment>> {
+    public async getPaymentsByIds(paymentIds: string[]): Promise<Map<string, Payment>> {
         const browserNodePromise = await this.browserNodeProvider.getBrowserNode();
         const channelAddressPromise = await this.vectorUtils.getRouterChannelAddress();
         const configPromise = await this.configProvider.getConfig();
@@ -259,7 +95,7 @@ export class PaymentRepository implements IPaymentRepository {
             return paymentIds.includes(val.meta.paymentId);
         });
 
-        const payments = await this.getPaymentsByTransfers(activeTransfers, config, context, browserNode)
+        const payments = await this.paymentUtils.transfersToPayments(activeTransfers, config, context, browserNode)
 
         return payments.reduce((map, obj) => {
             map.set(obj.id, obj);

--- a/packages/hypernet-core/src/implementations/utilities/LinkUtils.ts
+++ b/packages/hypernet-core/src/implementations/utilities/LinkUtils.ts
@@ -1,0 +1,44 @@
+import { HypernetLink, InitializedHypernetContext, Payment, PullPayment, PushPayment } from "@interfaces/objects";
+import { ILinkUtils } from "@interfaces/utilities/ILinkUtils";
+
+export class LinkUtils implements ILinkUtils {
+    constructor() {}
+
+    /**
+     * Given an array of Vector transfers, return the corresponding Hypernet Payments.
+     * Internally, calls transfersToPayments()
+     * @param payments
+     * @param config 
+     * @param context 
+     * @param browserNode 
+     */
+    public async paymentsToHypernetLinks(payments: Payment[], context: InitializedHypernetContext): Promise<HypernetLink[]> {
+
+        const linksByCounterpartyId = new Map<string, HypernetLink>();
+
+        for (const payment of payments) {
+            // Now that it's converted, we can stick it in the hypernet link
+            let counterpartyId = payment.to == context.publicIdentifier ? payment.from : payment.to;
+            let link = linksByCounterpartyId.get(counterpartyId);
+            if (link == null) {
+                link = new HypernetLink(counterpartyId, [], [], [], [], []);
+                linksByCounterpartyId.set(counterpartyId, link);
+            }
+
+            link.payments.push(payment);
+
+            if (payment instanceof PullPayment) {
+                link.pullPayments.push(payment);
+                link.activePullPayments.push(payment);
+            } else if (payment instanceof PushPayment) {
+                link.pushPayments.push(payment);
+                link.activePushPayments.push(payment);
+            } else {
+                throw new Error("Unknown payment type!");
+            }
+        }
+
+        // Convert to an array for return
+        return Array.from(linksByCounterpartyId.values());
+    }
+}

--- a/packages/hypernet-core/src/implementations/utilities/PaymentUtils.ts
+++ b/packages/hypernet-core/src/implementations/utilities/PaymentUtils.ts
@@ -1,10 +1,21 @@
-import { EPaymentType } from "@interfaces/types";
-import { IConfigProvider, IPaymentUtils } from "@interfaces/utilities";
+import { IConfigProvider, IPaymentUtils, IVectorUtils } from "@interfaces/utilities";
 import { v4 as uuidv4 } from "uuid";
+import { BigNumber, HypernetConfig, IHypernetTransferMetadata, InitializedHypernetContext, Payment, PublicIdentifier, PullAmount, PullPayment, PushPayment } from "@interfaces/objects";
+import { FullTransferState} from "@connext/vector-types";
+import { BrowserNode } from "@connext/vector-browser-node";
+import { EPaymentState, EPaymentType, ETransferType } from "@interfaces/types";
+import moment from "moment";
+import { ISortedTransfers } from "@interfaces/utilities";
 
 export class PaymentUtils implements IPaymentUtils {
-    constructor(protected configProvider: IConfigProvider) {}
+    constructor(
+        protected configProvider: IConfigProvider,
+    ) {}
     
+    /**
+     * 
+     * @param paymentId 
+     */
     public async isHypernetDomain(paymentId: string): Promise<boolean> {
         const config = await this.configProvider.getConfig();
 
@@ -13,9 +24,304 @@ export class PaymentUtils implements IPaymentUtils {
         return paymentComponents[0] == config.hypernetProtocolDomain;
     }
     
+    /**
+     * 
+     * @param paymentType 
+     */
     public async createPaymentId(paymentType: EPaymentType): Promise<string> {
         const config = await this.configProvider.getConfig();
 
         return `${config.hypernetProtocolDomain}:${paymentType}:${uuidv4()}`;
     }
+
+    /**
+     * 
+     * @param id 
+     * @param to 
+     * @param from 
+     * @param state 
+     * @param sortedTransfers 
+     * @param metadata 
+     */
+    public transfersToPushPayment(id: string,
+        to: PublicIdentifier,
+        from: PublicIdentifier,
+        state: EPaymentState,
+        sortedTransfers: SortedTransfers,
+        metadata: IHypernetTransferMetadata): PushPayment {
+
+        /**
+         * Push payments consist of 3 transfers, a null transfer for 0 value that represents the 
+         * offer, an insurance payment, and a parameterized payment. 
+         */
+
+        if (sortedTransfers.pullRecordTransfers.length > 0) {
+            throw new Error("Push payment has pull transfers!");
+        }
+
+        const amountStaked = sortedTransfers.insuranceTransfer != null ? sortedTransfers.insuranceTransfer.balance.amount[0] : 0;
+
+        return new PushPayment(
+            id,
+            to,
+            from,
+            state,
+            sortedTransfers.offerTransfer.assetId,
+            BigNumber.from(metadata.requiredStake),
+            BigNumber.from(amountStaked),
+            102,
+            false,
+            moment(),
+            moment(),
+            BigNumber.from(0),
+            metadata.disputeMediator,
+            BigNumber.from(metadata.paymentAmount),
+        );
+    }
+
+    /**
+     * 
+     * @param id 
+     * @param to 
+     * @param from 
+     * @param state 
+     * @param sortedTransfers 
+     * @param metadata 
+     */
+    public transfersToPullPayment(
+        id: string,
+        to: PublicIdentifier,
+        from: PublicIdentifier,
+        state: EPaymentState,
+        sortedTransfers: SortedTransfers,
+        metadata: IHypernetTransferMetadata): PullPayment {
+            
+        /**
+         * Push payments consist of 3 transfers, a null transfer for 0 value that represents the 
+         * offer, an insurance payment, and a parameterized payment. 
+         */
+
+        if (sortedTransfers.pullRecordTransfers.length > 0) {
+            throw new Error("Push payment has pull transfers!");
+        }
+
+        const amountStaked = sortedTransfers.insuranceTransfer != null ? sortedTransfers.insuranceTransfer.balance.amount[0] : 0;
+
+        return new PullPayment(id,
+            to,
+            from,
+            state,
+            sortedTransfers.offerTransfer.assetId,
+            BigNumber.from(metadata.requiredStake),
+            BigNumber.from(amountStaked),
+            102,
+            false,
+            moment.unix(metadata.creationDate),
+            moment(),
+            BigNumber.from(0),
+            metadata.disputeMediator,
+            BigNumber.from(metadata.paymentAmount),
+            BigNumber.from(0),
+            new Array<PullAmount>()
+        );
+    }
+
+    /**
+     *
+     * @param fullPaymentId 
+     * @param transfers 
+     * @param config 
+     * @param browserNode 
+     */
+    public async transfersToPayment(
+        fullPaymentId: string,
+        transfers: FullTransferState[],
+        config: HypernetConfig,
+        browserNode: BrowserNode): Promise<Payment> {
+
+        // const signerAddress = getSignerAddressFromPublicIdentifier(context.publicIdentifier);
+
+        let [domain, paymentType, id] = fullPaymentId.split(":");
+        if (domain != config.hypernetProtocolDomain) {
+            throw new Error(`Invalid payment domain: ${domain}`);
+        }
+
+        if (id == "" || id == null) {
+            throw new Error(`Missing id component of paymentId`);
+        }
+
+        const sortedTransfers = await this.sortTransfers(fullPaymentId, transfers, browserNode);
+
+        // Determine the state of the payment. All transfers we've been given are
+        // "Active", therefore, not resolved. So we don't need to figure out if
+        // the transfer is resolved, we know it's not.
+        // Given that info, the payment state is never going to be Finalized,
+        // because those transfers disappear.
+
+        let paymentState = EPaymentState.Proposed;
+        if (sortedTransfers.insuranceTransfer != null &&
+            sortedTransfers.parameterizedTransfer == null) {
+            paymentState = EPaymentState.Staked;
+        }
+        else if (sortedTransfers.insuranceTransfer != null &&
+            sortedTransfers.parameterizedTransfer != null) {
+            paymentState = EPaymentState.Approved;
+        }
+
+        // TODO: Figure out how to determine if the payment is Disputed
+
+        if (paymentType == EPaymentType.Pull) {
+            return this.transfersToPullPayment(
+                id,
+                sortedTransfers.metadata.to,
+                sortedTransfers.metadata.from,
+                paymentState,
+                sortedTransfers,
+                sortedTransfers.offerTransfer.meta);
+        } else if (paymentType == EPaymentType.Push) {
+            return this.transfersToPushPayment(
+                id,
+                sortedTransfers.metadata.to,
+                sortedTransfers.metadata.from,
+                paymentState,
+                sortedTransfers,
+                sortedTransfers.offerTransfer.meta);
+        } else {
+            throw new Error(`Unknown`)
+        }
+    }
+
+    /**
+     * Given an array of Vector transfers, return the corresponding Hypernet Payments
+     * @param transfers 
+     * @param config 
+     * @param context 
+     * @param browserNode 
+     */
+    public async transfersToPayments(
+        transfers: FullTransferState[], 
+        config: HypernetConfig,
+        context: InitializedHypernetContext,
+        browserNode: BrowserNode): Promise<Payment[]> {
+
+        // First, we are going to sort the transfers into buckets based on their payment_id
+        let transfersByPaymentId = new Map<string, FullTransferState[]>();
+        for (let transfer of transfers) {
+            const paymentId = transfer.meta.paymentId;
+
+            // Get the existing array of payments. Initialize it if it's not there.
+            let transferArray = transfersByPaymentId.get(paymentId);
+            if (transferArray == undefined) {
+                transferArray = [];
+                transfersByPaymentId.set(paymentId, transferArray);
+            }
+
+            transferArray.push(transfer);
+        }
+
+        // Now we have the transfers sorted by their payment ID.
+        // Loop over them and convert them to proper payments.
+        // This is all async, so we can do the whole thing in parallel.
+        const paymentPromises = new Array<Promise<Payment>>();
+        transfersByPaymentId.forEach(async (transferArray, paymentId) => {
+            const payment = this.transfersToPayment(
+                paymentId,
+                transferArray,
+                config,
+                browserNode);
+
+            paymentPromises.push(payment);
+        });
+        
+        // Convert all the transfers to payments
+        const payments = await Promise.all(paymentPromises);
+
+        return payments;
+    }
+
+    /**
+     * 
+     * @param transfer 
+     */
+    public getTransferType(transfer: FullTransferState): ETransferType {
+        // Have to jump through some hoops here
+        // TODO: Fix this.
+        return ETransferType.Offer;
+    }
+
+    /**
+     * 
+     * @param paymentId 
+     * @param transfers 
+     * @param browserNode 
+     */
+    public async sortTransfers(
+        paymentId: string,
+        transfers: FullTransferState[],
+        browserNode: BrowserNode): Promise<SortedTransfers> {
+
+        // We need to do a lookup for non-active transfers for the payment ID.
+        // TODO
+        // let inactiveTransfers = await browserNode.getTransfers((transfer) => {return transfer.meta.paymentId == fullPaymentId;});
+        // transfers.concat(inactiveTransfers);
+
+        const offerTransfers = transfers.filter((val) => {
+            return this.getTransferType(val) == ETransferType.Offer;
+        });
+        
+        const insuranceTransfers = transfers.filter((val) => {
+            return this.getTransferType(val) == ETransferType.Insurance;
+        });
+        
+        const parameterizedTransfers = transfers.filter((val) => {
+            return this.getTransferType(val) == ETransferType.Parameterized;
+        });
+
+        const pullTransfers = transfers.filter((val) => {
+            return this.getTransferType(val) == ETransferType.PullRecord;
+        });
+
+        const unrecognizedTransfers = transfers.filter((val) => {
+            return this.getTransferType(val) == ETransferType.Unrecognized;
+        });
+
+        if (unrecognizedTransfers.length > 0) {
+            throw new Error("Payment includes unrecognized transfer types!")
+        }
+
+        if (offerTransfers.length != 1) {
+            // TODO: this could be handled more elegantly; if there's other payments
+            // but no offer, it's still a valid payment
+            throw new Error("Invalid payment, no offer transfer!")
+        }
+        const offerTransfer = offerTransfers[0];
+
+        let insuranceTransfer: FullTransferState | null = null;
+        if (insuranceTransfers.length == 1) {
+            insuranceTransfer = insuranceTransfers[0];
+        } else if (insuranceTransfers.length > 1) {
+            throw new Error("Invalid payment, too many insurance transfers!");
+        }
+
+        let parameterizedTransfer: FullTransferState | null = null;
+        if (parameterizedTransfers.length == 1) {
+            parameterizedTransfer = parameterizedTransfers[0];
+        } else if (parameterizedTransfers.length > 1) {
+            throw new Error("Invalid payment, too many parameterized transfers!");
+        }
+
+        return new SortedTransfers(offerTransfer,
+            insuranceTransfer,
+            parameterizedTransfer,
+            pullTransfers,
+            offerTransfer.meta);
+    }
+}
+
+export class SortedTransfers implements ISortedTransfers {
+    constructor(public offerTransfer: FullTransferState,
+        public insuranceTransfer: FullTransferState | null,
+        public parameterizedTransfer: FullTransferState | null,
+        public pullRecordTransfers: FullTransferState[],
+        public metadata: IHypernetTransferMetadata) { }
 }

--- a/packages/hypernet-core/src/interfaces/business/ILinkService.ts
+++ b/packages/hypernet-core/src/interfaces/business/ILinkService.ts
@@ -1,5 +1,9 @@
 import { HypernetLink } from "@interfaces/objects";
 
 export interface ILinkService {
+
+    /**
+     * 
+     */
     getLedgers(): Promise<HypernetLink[]>;
 }

--- a/packages/hypernet-core/src/interfaces/business/IPaymentService.ts
+++ b/packages/hypernet-core/src/interfaces/business/IPaymentService.ts
@@ -1,21 +1,25 @@
 import {
-  HypernetLink,
   BigNumber,
   Payment,
   EthereumAddress,
   PublicKey,
-  ControlClaim,
-  HypernetConfig,
   PublicIdentifier,
-  Balances,
 } from "@interfaces/objects";
 
 /**
- * @todo What is the main role/purpose of this class? Description here.
- * @todo delete this entirely?
+ *
  */
 export interface IPaymentService {
   
+  /**
+   * 
+   * @param counterPartyAccount 
+   * @param amount 
+   * @param expirationDate 
+   * @param requiredStake 
+   * @param paymentToken 
+   * @param disputeMediator 
+   */
   sendFunds(
     counterPartyAccount: PublicIdentifier,
     amount: BigNumber,
@@ -24,10 +28,23 @@ export interface IPaymentService {
     paymentToken: EthereumAddress,
     disputeMediator: PublicKey): Promise<Payment>
 
+  /**
+   * 
+   * @param channelId 
+   * @param amount 
+   */
   requestPayment(channelId: string, amount: BigNumber): Promise<Payment>;
 
+  /**
+   * 
+   * @param paymentId 
+   */
   paymentPosted(paymentId: string): Promise<void>;
 
+  /**
+   * 
+   * @param paymentId 
+   */
   pullRecorded(paymentId: string): Promise<void>;
 
   /**

--- a/packages/hypernet-core/src/interfaces/data/ILinkRepository.ts
+++ b/packages/hypernet-core/src/interfaces/data/ILinkRepository.ts
@@ -1,10 +1,7 @@
-import { BrowserNode } from "@connext/vector-browser-node";
-import { FullTransferState } from "@connext/vector-types";
-import { BigNumber, EthereumAddress, HypernetConfig, HypernetLink, InitializedHypernetContext, Payment, PublicIdentifier, PublicKey } from "@interfaces/objects";
-
+import { HypernetLink, Payment} from "@interfaces/objects";
 
 /**
- * @todo What is the main role/purpose of this class? Description here.
+ * 
  */
 export interface ILinkRepository {
 
@@ -19,12 +16,21 @@ export interface ILinkRepository {
      */
     getHypernetLink(linkId: string): Promise<HypernetLink>;
 
-    getHypernetLinksByPayments(
-        payments: Payment[],
-        context: InitializedHypernetContext,
-    ): Promise<HypernetLink[]>;
-
+    /**
+     * 
+     * @param paymentIds 
+     */
     provideAssets(paymentIds: string[]): Promise<Map<string, Payment>> 
+
+    /**
+     * 
+     * @param paymentIds 
+     */
     provideStakes(paymentIds: string[]): Promise<Map<string, Payment>>
+
+    /**
+     * 
+     * @param paymentIds 
+     */
     finalizePayments(paymentIds: string[]): Promise<Map<string, Payment>>
 }

--- a/packages/hypernet-core/src/interfaces/data/IPaymentRepository.ts
+++ b/packages/hypernet-core/src/interfaces/data/IPaymentRepository.ts
@@ -1,32 +1,14 @@
-import { ILinkRepository } from "@interfaces/data";
-import { BigNumber, HypernetConfig, HypernetContext, HypernetLink, IHypernetTransferMetadata, InitializedHypernetContext, Payment, PublicIdentifier, PullAmount, PullPayment, PushPayment } from "@interfaces/objects";
-import { IBrowserNodeProvider, IConfigProvider, IContextProvider, IPaymentUtils, IVectorUtils } from "@interfaces/utilities";
-import { FullTransferState, NodeResponses } from "@connext/vector-types";
-import { EPaymentState, EPaymentType, ETransferType } from "@interfaces/types";
 import moment from "moment";
-import { BrowserNode } from "@connext/vector-browser-node";
 import { EthereumAddress, PublicKey } from "@interfaces/objects";
-import { SortedTransfers } from "@implementations/utilities";
+import { BigNumber, Payment, PublicIdentifier} from "@interfaces/objects";
 
 export interface IPaymentRepository {
-    getPaymentsById(paymentIds: string[]): Promise<Map<string, Payment>>;
-    getPaymentsByTransfers(transfers: FullTransferState[], config: HypernetConfig, context: InitializedHypernetContext, browserNode: BrowserNode): Promise<Payment[]>;
-    getPaymentByTransfers(fullPaymentId: string, transfers: FullTransferState[], config: HypernetConfig, browserNode: BrowserNode): Promise<Payment>;
+    /**
+     * 
+     * @param paymentIds 
+     */
+    getPaymentsByIds(paymentIds: string[]): Promise<Map<string, Payment>>;
 
-    getPullPaymentByTransfers(id: string,
-        to: PublicIdentifier,
-        from: PublicIdentifier,
-        state: EPaymentState,
-        sortedTransfers: SortedTransfers,
-        metadata: IHypernetTransferMetadata): PullPayment;
-
-    getPushPaymentByTransfers(id: string,
-        to: PublicIdentifier,
-        from: PublicIdentifier,
-        state: EPaymentState,
-        sortedTransfers: SortedTransfers,
-        metadata: IHypernetTransferMetadata): PushPayment;
-    
     /**
      * Creates a push payment and returns it. Nothing moves until
      * the payment is accepted; the payment will return with the

--- a/packages/hypernet-core/src/interfaces/utilities/ILinkUtils.ts
+++ b/packages/hypernet-core/src/interfaces/utilities/ILinkUtils.ts
@@ -1,0 +1,6 @@
+import { HypernetLink, InitializedHypernetContext, Payment } from "@interfaces/objects";
+
+export interface ILinkUtils {
+    paymentsToHypernetLinks(payments: Payment[], context: InitializedHypernetContext): Promise<HypernetLink[]> 
+    
+}

--- a/packages/hypernet-core/src/interfaces/utilities/IPaymentUtils.ts
+++ b/packages/hypernet-core/src/interfaces/utilities/IPaymentUtils.ts
@@ -1,6 +1,105 @@
-import { EPaymentType } from "@interfaces/types";
+import { HypernetConfig, IHypernetTransferMetadata, InitializedHypernetContext, Payment, PublicIdentifier, PullPayment, PushPayment } from "@interfaces/objects";
+import { FullTransferState} from "@connext/vector-types";
+import { EPaymentState, EPaymentType, ETransferType } from "@interfaces/types";
+import { BrowserNode } from "@connext/vector-browser-node";
+import { SortedTransfers } from "@implementations/utilities";
 
 export interface IPaymentUtils {
+    
+    /**
+     * 
+     * @param paymentId 
+     */
     isHypernetDomain(paymentId: string): Promise<boolean>;
+
+    /**
+     * 
+     * @param paymentType 
+     */
     createPaymentId(paymentType: EPaymentType): Promise<string>;
+
+    /**
+     * 
+     * @param transfers 
+     * @param config 
+     * @param context 
+     * @param browserNode 
+     */
+    transfersToPayments(
+        transfers: FullTransferState[], 
+        config: HypernetConfig, 
+        context: InitializedHypernetContext, 
+        browserNode: BrowserNode): Promise<Payment[]>;
+
+    /**
+     * 
+     * @param fullPaymentId 
+     * @param transfers 
+     * @param config 
+     * @param browserNode 
+     */
+    transfersToPayment(
+        fullPaymentId: string, 
+        transfers: FullTransferState[], 
+        config: HypernetConfig, 
+        browserNode: BrowserNode): Promise<Payment>;
+
+    /**
+     * 
+     * @param paymentId 
+     * @param transfers 
+     * @param browserNode 
+     */
+    sortTransfers(
+        paymentId: string, 
+        transfers: FullTransferState[], 
+        browserNode: BrowserNode): Promise<ISortedTransfers>;
+
+    /**
+     * 
+     * @param transfer 
+     */
+    getTransferType(transfer: FullTransferState): ETransferType;
+
+    /**
+     * 
+     * @param id 
+     * @param to 
+     * @param from 
+     * @param state 
+     * @param sortedTransfers 
+     * @param metadata 
+     */
+    transfersToPullPayment(
+        id: string,
+        to: PublicIdentifier,
+        from: PublicIdentifier,
+        state: EPaymentState,
+        sortedTransfers: SortedTransfers,
+        metadata: IHypernetTransferMetadata): PullPayment;
+
+    /**
+     * 
+     * @param id 
+     * @param to 
+     * @param from 
+     * @param state 
+     * @param sortedTransfers 
+     * @param metadata 
+     */
+    transfersToPushPayment(
+        id: string,
+        to: PublicIdentifier,
+        from: PublicIdentifier,
+        state: EPaymentState,
+        sortedTransfers: SortedTransfers,
+        metadata: IHypernetTransferMetadata): PushPayment;
+}
+
+export interface ISortedTransfers {
+    offerTransfer: FullTransferState,
+    insuranceTransfer: FullTransferState | null,
+    parameterizedTransfer: FullTransferState | null,
+    pullRecordTransfers: FullTransferState[],
+    metadata: IHypernetTransferMetadata
 }

--- a/packages/hypernet-core/src/interfaces/utilities/IVectorUtils.ts
+++ b/packages/hypernet-core/src/interfaces/utilities/IVectorUtils.ts
@@ -1,10 +1,8 @@
-import { BrowserNode } from "@connext/vector-browser-node";
 import { FullTransferState } from "@connext/vector-types";
 import { IHypernetTransferMetadata, PublicIdentifier } from "@interfaces/objects";
-import { ETransferType } from "@interfaces/types";
 
 /**
- * @todo What is the main role/purpose of this class? Description here.
+ * 
  */
 export interface IVectorUtils {
 
@@ -13,17 +11,10 @@ export interface IVectorUtils {
      */
     getRouterChannelAddress(): Promise<string>;
 
-    getTransferType(transfer: FullTransferState): ETransferType;
-
-    
-    createNullTransfer(counterParty: PublicIdentifier, metadata: IHypernetTransferMetadata): Promise<FullTransferState>;
-    sortTransfers(paymentId: string, transfers: FullTransferState[], browserNode: BrowserNode): Promise<ISortedTransfers>;
-}
-
-export interface ISortedTransfers {
-    offerTransfer: FullTransferState,
-    insuranceTransfer: FullTransferState | null,
-    parameterizedTransfer: FullTransferState | null,
-    pullRecordTransfers: FullTransferState[],
-    metadata: IHypernetTransferMetadata
+    /**
+     * 
+     * @param counterParty 
+     * @param metadata 
+     */
+    createNullTransfer(counterParty: PublicIdentifier, metadata: IHypernetTransferMetadata): Promise<FullTransferState>; 
 }


### PR DESCRIPTION
I've separated off payments into its own PaymentRepository, so now the process to get your hypernet links (inside of LinkRepository) is as follows:

LinkRepository gets transfers from the browser node (same as before)
LinkRepository calls into PaymentRepository: getPaymentsByTransfers <-- this could be problematic?
LinkRepository then uses one of its own functions: getLinksByPayments, and then returns the link