### PR TITLE
Fix the start time calculation for parameterized payments.

### DIFF
--- a/packages/developer-ui/package.json
+++ b/packages/developer-ui/package.json
@@ -32,16 +32,14 @@
     "test": "test"
   },
   "scripts": {
-    "Start-windows": "yarn start-backend && yarn deploy-custom-transfers && yarn start-web",
     "bootstrap": "docker-compose down && docker-compose pull && docker-compose up -d && wait-on -l -d 15000 package.json && docker-compose up -d && yarn verify-backend && yarn deploy-custom-transfers",
+    "start": "yarn start-backend && yarn start-web",
     "build": "webpack",
     "clean-docker": "docker-compose down",
     "compile": "tsc -b src/tsconfig.json",
     "deploy-custom-transfers": "yarn ts-node scripts/deploy.ts",
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "tslint -p src/tsconfig.json",
-    "quick-start": "yarn start-web",
-    "start": "yarn start-backend && yarn start-web",
     "start-backend": "docker-compose up -d && yarn verify-backend",
     "start-vector": "docker run -d -p 3001:80 vector-unit:latest",
     "start-web": "webpack serve --config webpack.config.js --mode development --open",

--- a/packages/hypernet-core/src/implementations/HypernetCore.ts
+++ b/packages/hypernet-core/src/implementations/HypernetCore.ts
@@ -198,7 +198,6 @@ export class HypernetCore implements IHypernetCore {
     });
 
     this.logUtils = new LogUtils();
-    this.timeUtils = new TimeUtils();
     this.localStorageUtils = new LocalStorageUtils();
     this.contextProvider = new ContextProvider(
       this.onControlClaimed,
@@ -219,6 +218,7 @@ export class HypernetCore implements IHypernetCore {
       this.onMerchantIFrameDisplayed,
     );
     this.blockchainProvider = new EthersBlockchainProvider(externalProvider);
+    this.timeUtils = new TimeUtils(this.blockchainProvider);
     this.paymentIdUtils = new PaymentIdUtils();
     this.configProvider = new ConfigProvider(network, this.logUtils, config);
     this.linkUtils = new LinkUtils(this.contextProvider);

--- a/packages/hypernet-core/src/implementations/utilities/BlockchainProvider.ts
+++ b/packages/hypernet-core/src/implementations/utilities/BlockchainProvider.ts
@@ -80,4 +80,10 @@ export class EthersBlockchainProvider implements IBlockchainProvider {
       return this.signer;
     });
   }
+
+  public getLatestBlock(): ResultAsync<ethers.providers.Block, BlockchainUnavailableError> {
+    return this.getProvider().map(async(provider) => {
+      return await provider.getBlock("latest");
+    });
+  }
 }

--- a/packages/hypernet-core/src/implementations/utilities/TimeUtils.ts
+++ b/packages/hypernet-core/src/implementations/utilities/TimeUtils.ts
@@ -1,8 +1,32 @@
-import { ITimeUtils } from "@interfaces/utilities";
+import { okAsync, ResultAsync } from "@interfaces/objects";
+import { BlockchainUnavailableError } from "@interfaces/objects/errors";
+import { IBlockchainProvider, ITimeUtils } from "@interfaces/utilities";
 import moment from "moment";
 
 export class TimeUtils implements ITimeUtils {
-  getUnixNow(): number {
+  protected lastBlockchainCheck: number | undefined;
+  protected lastBlockchainTimestamp: number | undefined;
+  constructor(protected blockchainProvider: IBlockchainProvider) {}
+
+  public getUnixNow(): number {
     return moment().unix();
+  }
+
+  public getBlockchainTimestamp(): ResultAsync<number, BlockchainUnavailableError> {
+    const now = this.getUnixNow();
+
+    // We can return a cached value if the last time we checked was this second
+    if (this.lastBlockchainCheck != null && 
+      this.lastBlockchainTimestamp != null && 
+      this.lastBlockchainCheck >= now) {
+      return okAsync(this.lastBlockchainTimestamp);
+    }
+    
+    this.lastBlockchainCheck = now;
+    return this.blockchainProvider.getLatestBlock()
+    .map((block) => {
+      this.lastBlockchainTimestamp = block.timestamp;
+      return block.timestamp;
+    });
   }
 }

--- a/packages/hypernet-core/src/implementations/utilities/VectorUtils.ts
+++ b/packages/hypernet-core/src/implementations/utilities/VectorUtils.ts
@@ -18,7 +18,6 @@ import {
   IPaymentIdUtils,
   IBrowserNode,
   IBasicTransferResponse,
-  IBasicChannelResponse,
   IFullChannelState,
   IFullTransferState,
   ITimeUtils,
@@ -106,11 +105,13 @@ export class VectorUtils implements IVectorUtils {
     let channelAddress: string;
     let browserNode: IBrowserNode;
 
-    return ResultUtils.combine([this.browserNodeProvider.getBrowserNode(), this.getRouterChannelAddress()])
+    return ResultUtils.combine([this.browserNodeProvider.getBrowserNode(), this.getRouterChannelAddress(), this.blockchainProvider.getLatestBlock()])
       .andThen((vals) => {
-        const [browserNodeVal, channelAddressVal] = vals;
+        const [browserNodeVal, channelAddressVal, block] = vals;
         browserNode = browserNodeVal;
         channelAddress = channelAddressVal;
+
+        this.logUtils.debug(`Current block timestamp: ${block.timestamp}`);
 
         const resolverDataEncoding = ["tuple(bytes32 UUID, uint256 paymentAmountTaken)"];
         const encodedResolverData = defaultAbiCoder.encode(resolverDataEncoding, [resolverData]);

--- a/packages/hypernet-core/src/interfaces/utilities/IBlockchainProvider.ts
+++ b/packages/hypernet-core/src/interfaces/utilities/IBlockchainProvider.ts
@@ -11,4 +11,5 @@ export interface IBlockchainProvider {
     ethers.providers.Web3Provider | ethers.providers.JsonRpcProvider,
     BlockchainUnavailableError
   >;
+  getLatestBlock(): ResultAsync<ethers.providers.Block, BlockchainUnavailableError>;
 }

--- a/packages/hypernet-core/src/interfaces/utilities/ITimeUtils.ts
+++ b/packages/hypernet-core/src/interfaces/utilities/ITimeUtils.ts
@@ -1,3 +1,7 @@
+import { ResultAsync } from "@interfaces/objects";
+import { BlockchainUnavailableError } from "@interfaces/objects/errors";
+
 export interface ITimeUtils {
   getUnixNow(): number;
+  getBlockchainTimestamp(): ResultAsync<number, BlockchainUnavailableError>;
 }

--- a/packages/hypernet-core/test/mock/utils/BlockchainProviderMock.ts
+++ b/packages/hypernet-core/test/mock/utils/BlockchainProviderMock.ts
@@ -28,4 +28,8 @@ export class BlockchainProviderMock implements IBlockchainProvider {
   public getProvider(): ResultAsync<ethers.providers.Web3Provider, BlockchainUnavailableError> {
     return okAsync(this.provider);
   }
+
+  public getLatestBlock(): ResultAsync<ethers.providers.Block, BlockchainUnavailableError> {
+    return okAsync({} as ethers.providers.Block);
+  }
 }

--- a/packages/hypernet-core/test/unit/data/PaymentRepository.test.ts
+++ b/packages/hypernet-core/test/unit/data/PaymentRepository.test.ts
@@ -54,6 +54,7 @@ class PaymentRepositoryMocks {
     includeParameterizedTransfer: boolean = true,
   ) {
     td.when(this.timeUtils.getUnixNow()).thenReturn(unixNow);
+    td.when(this.timeUtils.getBlockchainTimestamp()).thenReturn(okAsync(unixNow));
 
     this.browserNodeProvider = new BrowserNodeProviderMock(
       includeOfferTransfer,

--- a/packages/hypernet-core/test/unit/data/VectorLinkRepository.test.ts
+++ b/packages/hypernet-core/test/unit/data/VectorLinkRepository.test.ts
@@ -88,6 +88,7 @@ class VectorLinkRepositoryMocks {
     ).thenReturn(okAsync([]));
 
     td.when(this.timeUtils.getUnixNow()).thenReturn(unixNow);
+    td.when(this.timeUtils.getBlockchainTimestamp()).thenReturn(okAsync(unixNow));
   }
 
   public factoryVectorLinkRepository(): ILinkRepository {

--- a/packages/hypernet-core/test/unit/utilities/VectorUtils.test.ts
+++ b/packages/hypernet-core/test/unit/utilities/VectorUtils.test.ts
@@ -20,6 +20,7 @@ class VectorUtilsMocks {
     td.when(this.browserNodeProvider.getBrowserNode()).thenReturn(okAsync(this.browserNodeMock));
 
     td.when(this.timeUtils.getUnixNow()).thenReturn(unixNow);
+    td.when(this.timeUtils.getBlockchainTimestamp()).thenReturn(okAsync(unixNow));
   }
 
   public factoryVectorUtils(): VectorUtils {


### PR DESCRIPTION
This prevents clock drift from making the payment unresolveable.