### PR TITLE
removed uups parent class

### DIFF
--- a/packages/contracts/contracts/governance/HypernetGovernor.sol
+++ b/packages/contracts/contracts/governance/HypernetGovernor.sol
@@ -24,6 +24,7 @@ contract HypernetGovernor is Governor, GovernorCompatibilityBravo, GovernorVotes
 
     mapping(uint256 => string) public proposalDescriptions; // description for each proposal
 
+    // be sure to set these to reasonable values for Mainnet
     uint256 private _votingDelay = 1; // blocks (1 block is about 13 seconds)
 
     uint256 private _votingPeriod = 20; // blocks

--- a/packages/contracts/contracts/identity/NonFungibleRegistryEnumerableUpgradeable.sol
+++ b/packages/contracts/contracts/identity/NonFungibleRegistryEnumerableUpgradeable.sol
@@ -10,15 +10,13 @@ import "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/cryptography/ECDSAUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
 contract NonFungibleRegistryEnumerableUpgradeable is
     Initializable,
     ContextUpgradeable,
     AccessControlEnumerableUpgradeable,
     ERC721EnumerableUpgradeable,
-    ERC721URIStorageUpgradeable,
-    UUPSUpgradeable
+    ERC721URIStorageUpgradeable
 {
     using CountersUpgradeable for CountersUpgradeable.Counter;
     using SafeERC20Upgradeable for IERC20Upgradeable;
@@ -111,7 +109,6 @@ contract NonFungibleRegistryEnumerableUpgradeable is
         __AccessControlEnumerable_init();
         __ERC721Enumerable_init();
         __ERC721URIStorage_init();
-        __UUPSUpgradeable_init();
         __ERC721_init(name_, symbol_);
 
         _setupRole(DEFAULT_ADMIN_ROLE, _admin);
@@ -130,9 +127,6 @@ contract NonFungibleRegistryEnumerableUpgradeable is
         burnFee = 500; // basis points, 500 bp = 5%
         primaryRegistry = address(0);
     }
-
-    // we must implement this function at top level contract definition for the upgradable proxy pattern
-    function _authorizeUpgrade(address newImplementation) internal onlyRole(REGISTRAR_ROLE) override {}
 
     /// @notice setRegistryParameters enable or disable the lazy registration feature
     /// @dev only callable by the REGISTRAR_ROLE, use arrays so we don't have to always pass every

--- a/packages/contracts/contracts/identity/NonFungibleRegistryUpgradeable.sol
+++ b/packages/contracts/contracts/identity/NonFungibleRegistryUpgradeable.sol
@@ -9,14 +9,12 @@ import "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/cryptography/ECDSAUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
 contract NonFungibleRegistryUpgradeable is
     Initializable,
     ContextUpgradeable,
     AccessControlEnumerableUpgradeable,
-    ERC721URIStorageUpgradeable,
-    UUPSUpgradeable
+    ERC721URIStorageUpgradeable
 {
     using CountersUpgradeable for CountersUpgradeable.Counter;
     using SafeERC20Upgradeable for IERC20Upgradeable;
@@ -108,7 +106,6 @@ contract NonFungibleRegistryUpgradeable is
         __Context_init();
         __AccessControlEnumerable_init();
         __ERC721URIStorage_init();
-        __UUPSUpgradeable_init();
         __ERC721_init(name_, symbol_);
 
         _setupRole(DEFAULT_ADMIN_ROLE, _admin);
@@ -127,9 +124,6 @@ contract NonFungibleRegistryUpgradeable is
         burnFee = 500; // basis points
         primaryRegistry = address(0);
     }
-
-    // we must implement this function at top level contract definition for the upgradable proxy pattern
-    function _authorizeUpgrade(address newImplementation) internal onlyRole(REGISTRAR_ROLE) override {}
 
     /// @notice setRegistryParameters enable or disable the lazy registration feature
     /// @dev only callable by the REGISTRAR_ROLE, use arrays so we don't have to always pass every

--- a/packages/contracts/contracts/identity/UpgradeableRegistryFactory.sol
+++ b/packages/contracts/contracts/identity/UpgradeableRegistryFactory.sol
@@ -33,7 +33,7 @@ contract UpgradeableRegistryFactory is AccessControlEnumerable {
     uint256 public registrationFee = 50e18; // assume 18 decimal places
 
     // address that token is sent to after registry creation
-    address public burnAddress = address(0x000000000000000000000000000000000000dEaD);
+    address public burnAddress;
 
     /**
      * @dev Emitted when `DEFAULT_ADMIN_ROLE` creates a new registry.
@@ -72,6 +72,7 @@ contract UpgradeableRegistryFactory is AccessControlEnumerable {
         registryBeacon = address(_registryBeacon);
 
         registrationToken = _registrationToken;
+        burnAddress = _admin;
 
         // deploy initial enumerable registries 
         for (uint256 i = 0; i < _names.length; ++i) {

--- a/packages/contracts/test/upgradeable-factory-test.js
+++ b/packages/contracts/test/upgradeable-factory-test.js
@@ -176,6 +176,8 @@ describe("Registry Factory Unit Tests", function () {
         tx = await hypertoken.connect(addr1).approve(registryfactory.address, fee);
         tx.wait();
 
+        const previousBalance = await hypertoken.balanceOf(burnAddress);
+
         tx = await registryfactory.connect(addr1).createRegistryByToken("enumerabledummy", "edmy", addr1.address, true);
         tx.wait();
 
@@ -184,7 +186,7 @@ describe("Registry Factory Unit Tests", function () {
 
         expect(await registryfactory.getNumberOfEnumerableRegistries()).to.equal(2);
         expect(await hypertoken.balanceOf(addr1.address)).to.equal(fee);
-        expect(await hypertoken.balanceOf(burnAddress)).to.equal(fee);
+        expect(await hypertoken.balanceOf(burnAddress)).to.equal(previousBalance.add(fee));
         expect(await dummyReg.name()).to.equal("enumerabledummy");
         expect(await dummyReg.symbol()).to.equal("edmy");
 


### PR DESCRIPTION
inheriting from UUPSUpgradeable was not necessary since the registry factory is using the UpgradeableBeacon pattern, so UUPS was removed from both the enumerable and non-enumerable registry contracts