### PR TITLE
Change RegistryTokenId

### DIFF
--- a/packages/gateway-connector/package.json
+++ b/packages/gateway-connector/package.json
@@ -41,7 +41,7 @@
   },
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@hypernetlabs/objects": "^0.3.16",
+    "@hypernetlabs/objects": "^0.3.17",
     "ethers": "^5.4.7"
   }
 }

--- a/packages/gateway-iframe/package.json
+++ b/packages/gateway-iframe/package.json
@@ -45,7 +45,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@hypernetlabs/gateway-connector": "^0.0.13",
-    "@hypernetlabs/objects": "^0.3.16",
+    "@hypernetlabs/objects": "^0.3.17",
     "@hypernetlabs/utils": "^0.5.2",
     "ethers": "^5.4.7",
     "inversify": "^5.1.1",

--- a/packages/governance-sdk/package.json
+++ b/packages/governance-sdk/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@hypernetlabs/gateway-connector": "^0.0.12",
-    "@hypernetlabs/objects": "^0.3.16",
+    "@hypernetlabs/objects": "^0.3.17",
     "@hypernetlabs/utils": "^0.5.2",
     "ethers": "^5.4.7",
     "neverthrow": "^4.2.2"

--- a/packages/governance-sdk/src/NonFungibleRegistryEnumerableUpgradeableContract.ts
+++ b/packages/governance-sdk/src/NonFungibleRegistryEnumerableUpgradeableContract.ts
@@ -406,7 +406,7 @@ export class NonFungibleRegistryEnumerableUpgradeableContract
           e,
         );
       },
-    ).map((tokenId) => RegistryTokenId(tokenId.toNumber()));
+    ).map((tokenId) => RegistryTokenId(tokenId.toBigInt()));
   }
 
   public tokenOfOwnerByIndex(
@@ -427,7 +427,7 @@ export class NonFungibleRegistryEnumerableUpgradeableContract
           e,
         );
       },
-    ).map((tokenId) => RegistryTokenId(tokenId.toNumber()));
+    ).map((tokenId) => RegistryTokenId(tokenId.toBigInt()));
   }
 
   public registryMap(
@@ -955,7 +955,7 @@ export class NonFungibleRegistryEnumerableUpgradeableContract
           },
         ).andThen((tokenId) => {
           return this.getRegistryEntryByTokenId(
-            RegistryTokenId(tokenId.toNumber()),
+            RegistryTokenId(tokenId.toBigInt()),
             registryAddress,
           );
         });

--- a/packages/hypernet-core/package.json
+++ b/packages/hypernet-core/package.json
@@ -50,7 +50,7 @@
     "@hypernetlabs/common-repositories": "^0.0.3",
     "@hypernetlabs/gateway-connector": "^0.0.12",
     "@hypernetlabs/governance-sdk": "^0.0.4",
-    "@hypernetlabs/objects": "^0.3.16",
+    "@hypernetlabs/objects": "^0.3.17",
     "@hypernetlabs/utils": "^0.5.2",
     "@walletconnect/web3-provider": "^1.5.2",
     "class-transformer": "^0.3.2",

--- a/packages/hypernet-core/src/implementations/data/RegistryRepository.ts
+++ b/packages/hypernet-core/src/implementations/data/RegistryRepository.ts
@@ -1,3 +1,4 @@
+import { DIDDataStore } from "@glazed/did-datastore";
 import {
   IRegistryFactoryContract,
   IERC20Contract,
@@ -37,6 +38,7 @@ import {
 } from "@hypernetlabs/objects";
 import { ResultUtils, ILogUtils, ILogUtilsType } from "@hypernetlabs/utils";
 import { IRegistryRepository } from "@interfaces/data";
+import { HypernetContext } from "@interfaces/objects";
 import { BigNumber, ethers } from "ethers";
 import { injectable, inject } from "inversify";
 import { errAsync, okAsync, ResultAsync } from "neverthrow";
@@ -49,8 +51,6 @@ import {
   IDIDDataStoreProvider,
   IDIDDataStoreProviderType,
 } from "@interfaces/utilities";
-import { HypernetContext } from "@interfaces/objects";
-import { DIDDataStore } from "@glazed/did-datastore";
 
 @injectable()
 export class RegistryRepository implements IRegistryRepository {
@@ -932,7 +932,10 @@ export class RegistryRepository implements IRegistryRepository {
         throw new Error("Registry not found!");
       }
 
-      if (newRegistryEntry.tokenId === 0 || isNaN(newRegistryEntry.tokenId)) {
+      if (
+        newRegistryEntry.tokenId === BigInt(0) ||
+        isNaN(Number(newRegistryEntry.tokenId))
+      ) {
         return errAsync(
           new NonFungibleRegistryContractError(
             "Zero number or strings are not allowed as a token ID.",
@@ -1327,7 +1330,7 @@ export class RegistryRepository implements IRegistryRepository {
         if (
           newRegistryEntries.some(
             (newRegistryEntry) =>
-              isNaN(newRegistryEntry.tokenId) ||
+              isNaN(Number(newRegistryEntry.tokenId)) ||
               newRegistryEntry.tokenId == null ||
               newRegistryEntry.owner == null ||
               newRegistryEntry.label == null,

--- a/packages/hypernet-core/test/mock/mocks/commonValues.ts
+++ b/packages/hypernet-core/test/mock/mocks/commonValues.ts
@@ -183,8 +183,8 @@ export const defaultGovernanceChainInformation = new GovernanceChainInformation(
   [ProviderUrl("http://localhost:8545")],
 );
 
-export const tokenRegistryId1 = RegistryTokenId(70916);
-export const tokenRegistryId2 = RegistryTokenId(103182);
+export const tokenRegistryId1 = RegistryTokenId(BigInt(70916));
+export const tokenRegistryId2 = RegistryTokenId(BigInt(103182));
 
 export const tokenRegistryEntry1 = new RegistryEntry(
   "TokenRegistryEntry1",

--- a/packages/iframe/package.json
+++ b/packages/iframe/package.json
@@ -21,7 +21,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@hypernetlabs/hypernet-core": "^0.0.1",
-    "@hypernetlabs/objects": "^0.3.16",
+    "@hypernetlabs/objects": "^0.3.17",
     "@hypernetlabs/utils": "^0.5.2",
     "@hypernetlabs/web-ui": "^5.0.21",
     "neverthrow": "^4.2.2",

--- a/packages/mobileApp/package.json
+++ b/packages/mobileApp/package.json
@@ -21,7 +21,7 @@
     "preset": "react-native"
   },
   "dependencies": {
-    "@hypernetlabs/objects": "^0.3.16",
+    "@hypernetlabs/objects": "^0.3.17",
     "@react-native-community/masked-view": "^0.1.10",
     "@react-navigation/bottom-tabs": "^5.11.7",
     "@react-navigation/native": "^5.9.2",

--- a/packages/objects/package.json
+++ b/packages/objects/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hypernetlabs/objects",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "description": "Objects and types shared by the Hypernet Protocol",
   "license": "ISC",
   "repository": {

--- a/packages/objects/src/RegistryTokenId.ts
+++ b/packages/objects/src/RegistryTokenId.ts
@@ -1,4 +1,4 @@
 import { Brand, make } from "ts-brand";
 
-export type RegistryTokenId = Brand<number, "RegistryTokenId">;
+export type RegistryTokenId = Brand<bigint, "RegistryTokenId">;
 export const RegistryTokenId = make<RegistryTokenId>();

--- a/packages/test-gateway-connector/package.json
+++ b/packages/test-gateway-connector/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@hypernetlabs/gateway-connector": "^0.0.12",
-    "@hypernetlabs/objects": "^0.3.16",
+    "@hypernetlabs/objects": "^0.3.17",
     "ethers": "^5.4.7",
     "neverthrow": "^4.2.2",
     "rxjs": "^6.6.6"

--- a/packages/test-gateway/package.json
+++ b/packages/test-gateway/package.json
@@ -41,7 +41,7 @@
   },
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@hypernetlabs/objects": "^0.3.16",
+    "@hypernetlabs/objects": "^0.3.17",
     "cors": "^2.8.5",
     "ethers": "^5.4.7",
     "express": "^4.17.1"

--- a/packages/user-dashboard/package.json
+++ b/packages/user-dashboard/package.json
@@ -42,7 +42,7 @@
   },
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@hypernetlabs/objects": "^0.3.16",
+    "@hypernetlabs/objects": "^0.3.17",
     "@hypernetlabs/web-integration": "^0.6.15",
     "@material-ui/core": "4.12.3",
     "path-to-regexp": "^6.2.0",

--- a/packages/user-dashboard/src/pages/Governance/RegistryEntryDetail/RegistryEntryDetail.tsx
+++ b/packages/user-dashboard/src/pages/Governance/RegistryEntryDetail/RegistryEntryDetail.tsx
@@ -21,7 +21,7 @@ const RegistryEntryDetail: React.FC = () => {
           history.push(`/registries/${registryName}/entries`);
         },
         registryName,
-        entryTokenId: RegistryTokenId(parseInt(entryTokenId)),
+        entryTokenId: RegistryTokenId(BigInt(entryTokenId)),
       })
       .mapErr(handleError);
   }, []);

--- a/packages/user-dashboard/src/pages/Governance/RegistryEntryList/RegistryEntryList.tsx
+++ b/packages/user-dashboard/src/pages/Governance/RegistryEntryList/RegistryEntryList.tsx
@@ -1,3 +1,4 @@
+import { RegistryTokenId } from "@hypernetlabs/objects";
 import { Box } from "@material-ui/core";
 import React, { useEffect } from "react";
 import { useHistory, useParams } from "react-router-dom";
@@ -17,7 +18,7 @@ const RegistryEntryList: React.FC = () => {
         selector: "registry-entry-list-page-wrapper",
         onRegistryEntryDetailsNavigate: (
           registryName: string,
-          entryTokenId: number,
+          entryTokenId: RegistryTokenId,
         ) => {
           history.push(`/registries/${registryName}/entries/${entryTokenId}`);
         },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -41,7 +41,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "@connext/vector-utils": "^0.2.5-beta.6",
-    "@hypernetlabs/objects": "^0.3.16",
+    "@hypernetlabs/objects": "^0.3.17",
     "axios": "^0.21.1",
     "delay": "^5.0.0",
     "inversify": "^5.1.1",

--- a/packages/web-integration/package.json
+++ b/packages/web-integration/package.json
@@ -27,7 +27,7 @@
   },
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@hypernetlabs/objects": "^0.3.16",
+    "@hypernetlabs/objects": "^0.3.17",
     "@hypernetlabs/utils": "^0.5.2",
     "@hypernetlabs/web-ui": "^5.0.21",
     "ethers": "^5.4.7",

--- a/packages/web-integration/src/implementations/proxy/HypernetIFrameProxy.ts
+++ b/packages/web-integration/src/implementations/proxy/HypernetIFrameProxy.ts
@@ -997,7 +997,7 @@ export default class HypernetIFrameProxy
 
     getRegistryEntryDetailByTokenId: (
       registryName: string,
-      tokenId: number,
+      tokenId: RegistryTokenId,
     ): ResultAsync<
       RegistryEntry,
       | RegistryFactoryContractError
@@ -1012,7 +1012,7 @@ export default class HypernetIFrameProxy
 
     updateRegistryEntryTokenURI: (
       registryName: string,
-      tokenId: number,
+      tokenId: RegistryTokenId,
       registrationData: string,
     ): ResultAsync<
       RegistryEntry,
@@ -1031,7 +1031,7 @@ export default class HypernetIFrameProxy
 
     updateRegistryEntryLabel: (
       registryName: string,
-      tokenId: number,
+      tokenId: RegistryTokenId,
       label: string,
     ): ResultAsync<
       RegistryEntry,
@@ -1089,7 +1089,7 @@ export default class HypernetIFrameProxy
 
     transferRegistryEntry: (
       registryName: string,
-      tokenId: number,
+      tokenId: RegistryTokenId,
       transferToAddress: EthereumAccountAddress,
     ): ResultAsync<
       RegistryEntry,
@@ -1108,7 +1108,7 @@ export default class HypernetIFrameProxy
 
     burnRegistryEntry: (
       registryName: string,
-      tokenId: number,
+      tokenId: RegistryTokenId,
     ): ResultAsync<
       void,
       | NonFungibleRegistryContractError

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -39,7 +39,7 @@
   },
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@hypernetlabs/objects": "^0.3.16",
+    "@hypernetlabs/objects": "^0.3.17",
     "ethers": "5.4.7",
     "react-alert": "^7.0.2",
     "react-alert-template-basic": "^1.0.0",

--- a/packages/web-ui/src/components/GovernanceValueWithTitle/GovernanceValueWithTitle.tsx
+++ b/packages/web-ui/src/components/GovernanceValueWithTitle/GovernanceValueWithTitle.tsx
@@ -1,11 +1,12 @@
-import React from "react";
+import { RegistryTokenId } from "@hypernetlabs/objects";
 import { Box, Typography } from "@material-ui/core";
+import React from "react";
 
 import { useStyles } from "@web-ui/components/GovernanceValueWithTitle/GovernanceValueWithTitle.style";
 
 export interface IGovernanceValueWithTitle {
   title: string;
-  value: string | number | undefined;
+  value: string | number | RegistryTokenId | undefined;
   topRightContent?: React.ReactNode;
   bottomRightContent?: React.ReactNode;
 }

--- a/packages/web-ui/src/interfaces/app/IHypernetWebUI.ts
+++ b/packages/web-ui/src/interfaces/app/IHypernetWebUI.ts
@@ -67,7 +67,7 @@ export interface IRegistryListWidgetParams extends IRenderParams {
 export interface IRegistryEntryListWidgetParams extends IRenderParams {
   onRegistryEntryDetailsNavigate?: (
     registryName: string,
-    entryTokenId: number,
+    entryTokenId: RegistryTokenId,
   ) => void;
   onRegistryListNavigate?: () => void;
   registryName: string;

--- a/packages/web-ui/src/widgets/CreateBatchIdentityWidget/CreateBatchIdentityWidget.tsx
+++ b/packages/web-ui/src/widgets/CreateBatchIdentityWidget/CreateBatchIdentityWidget.tsx
@@ -4,10 +4,10 @@ import {
   RegistryTokenId,
 } from "@hypernetlabs/objects";
 import { Box, Typography } from "@material-ui/core";
+import RemoveCircleOutlineIcon from "@material-ui/icons/RemoveCircleOutline";
 import { useStoreContext, useLayoutContext } from "@web-ui/contexts";
 import { Form, Formik, FormikState } from "formik";
 import React, { useState } from "react";
-import RemoveCircleOutlineIcon from "@material-ui/icons/RemoveCircleOutline";
 
 import {
   GovernanceDialog,
@@ -54,7 +54,7 @@ const CreateBatchIdentityWidget: React.FC<CreateBatchIdentityWidget> = ({
       registryEntries.push(
         new RegistryEntry(
           label,
-          RegistryTokenId(Number(tokenId)),
+          RegistryTokenId(BigInt(tokenId)),
           EthereumAccountAddress(recipientAddress),
           tokenUri,
           null,
@@ -110,7 +110,7 @@ const CreateBatchIdentityWidget: React.FC<CreateBatchIdentityWidget> = ({
         ...prevState,
         new RegistryEntry(
           values.label,
-          RegistryTokenId(Number(values.tokenId)),
+          RegistryTokenId(BigInt(values.tokenId)),
           EthereumAccountAddress(values.recipientAddress),
           values.tokenUri,
           null,

--- a/packages/web-ui/src/widgets/CreateIdentityWidget/CreateIdentityWidget.tsx
+++ b/packages/web-ui/src/widgets/CreateIdentityWidget/CreateIdentityWidget.tsx
@@ -55,7 +55,7 @@ const CreateIdentityWidget: React.FC<ICreateIdentityWidget> = ({
         registryName,
         new RegistryEntry(
           label,
-          RegistryTokenId(Number(tokenId)),
+          RegistryTokenId(BigInt(tokenId)),
           EthereumAccountAddress(recipientAddress),
           tokenUri,
           null,
@@ -78,7 +78,7 @@ const CreateIdentityWidget: React.FC<ICreateIdentityWidget> = ({
     coreProxy.registries
       .submitLazyMintSignature(
         registryName,
-        RegistryTokenId(Number(tokenId)),
+        RegistryTokenId(BigInt(tokenId)),
         EthereumAccountAddress(recipientAddress),
         tokenUri,
       )

--- a/packages/web-ui/src/widgets/RegistryEntryDetailWidget/RegistryEntryDetailWidget.tsx
+++ b/packages/web-ui/src/widgets/RegistryEntryDetailWidget/RegistryEntryDetailWidget.tsx
@@ -135,7 +135,7 @@ const RegistryEntryDetailWidget: React.FC<IRegistryEntryDetailWidgetParams> = ({
       return isRegistrar || isOwner;
     }, [isRegistrar, isOwner]);
 
-    let headerActions: IHeaderAction[] = [];
+    const headerActions: IHeaderAction[] = [];
 
     if (canBurn) {
       headerActions.push({

--- a/packages/web-ui/src/widgets/RegistryEntryListWidget/RegistryEntryListWidget.tsx
+++ b/packages/web-ui/src/widgets/RegistryEntryListWidget/RegistryEntryListWidget.tsx
@@ -1,5 +1,3 @@
-import React, { useEffect, useState, useMemo, useRef } from "react";
-import { Form, Formik } from "formik";
 import {
   ERegistrySortOrder,
   EthereumAccountAddress,
@@ -9,6 +7,8 @@ import {
 import { Box, Typography } from "@material-ui/core";
 import { useStoreContext, useLayoutContext } from "@web-ui/contexts";
 import { IRegistryEntryListWidgetParams } from "@web-ui/interfaces";
+import { Form, Formik } from "formik";
+import React, { useEffect, useState, useMemo, useRef } from "react";
 
 import {
   GovernanceRegistryListItem,
@@ -20,8 +20,8 @@ import {
   GovernanceSearchFilter,
   GovernanceDialogSelectField,
 } from "@web-ui/components";
-import CreateIdentityWidget from "@web-ui/widgets/CreateIdentityWidget";
 import CreateBatchIdentityWidget from "@web-ui/widgets/CreateBatchIdentityWidget";
+import CreateIdentityWidget from "@web-ui/widgets/CreateIdentityWidget";
 import { useStyles } from "@web-ui/widgets/RegistryEntryListWidget/RegistryEntryListWidget.style";
 
 const REGISTRY_ENTRIES_PER_PAGE = 3;
@@ -144,7 +144,7 @@ const RegistryEntryListWidget: React.FC<IRegistryEntryListWidgetParams> = ({
     const cansubmitLazyMintSignature =
       isRegistrar && registry?.modulesCapability.lazyMintEnabled;
 
-    let headerActions: IHeaderAction[] = [];
+    const headerActions: IHeaderAction[] = [];
 
     if (cansubmitLazyMintSignature) {
       headerActions.push({

--- a/packages/web-ui/src/widgets/RegistryLazyMintingRequestsWidget/RegistryLazyMintingRequestsWidget.tsx
+++ b/packages/web-ui/src/widgets/RegistryLazyMintingRequestsWidget/RegistryLazyMintingRequestsWidget.tsx
@@ -78,7 +78,7 @@ const RegistryLazyMintingRequestsWidget: React.FC<IRegistryLazyMintingRequestsWi
 
         {lazyMintingSignatures?.map((lazyMintingSignature, index) => (
           <GovernanceRegistryListItem
-            key={lazyMintingSignature.tokenId}
+            key={Number(lazyMintingSignature.tokenId)}
             number={(index + 1).toString()}
             title={lazyMintingSignature.tokenId.toString()}
             fieldWithValueList={[


### PR DESCRIPTION
This changes the base type of RegistryTokenId to bigint instead of number. The token ids can indeed be quite large, a lot bigger than a number, and I need that in Hypernet.ID in particular.