### PR TITLE
Extend ajax utils data types

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hypernetlabs/utils",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Utilities used by Hypernet Labs packages",
   "license": "ISC",
   "repository": {

--- a/packages/utils/src/AxiosAjaxUtils.ts
+++ b/packages/utils/src/AxiosAjaxUtils.ts
@@ -2,7 +2,7 @@ import { AjaxError, JsonWebToken } from "@hypernetlabs/objects";
 import axios, { AxiosResponse } from "axios";
 import { injectable } from "inversify";
 import { ResultAsync } from "neverthrow";
-import stream from 'stream';
+import { Readable } from "stream";
 
 import { IAjaxUtils, IRequestConfig } from "@utils/IAjaxUtils";
 
@@ -24,7 +24,7 @@ export class AxiosAjaxUtils implements IAjaxUtils {
       | Record<string, unknown>
       | ArrayBuffer
       | ArrayBufferView
-      | stream.Readable 
+      | Readable
       | URLSearchParams,
     config?: IRequestConfig,
   ): ResultAsync<T, AjaxError> {
@@ -43,7 +43,7 @@ export class AxiosAjaxUtils implements IAjaxUtils {
       | Record<string, unknown>
       | ArrayBuffer
       | ArrayBufferView
-      | stream.Readable 
+      | Readable
       | URLSearchParams,
     config?: IRequestConfig,
   ): ResultAsync<T, AjaxError> {

--- a/packages/utils/src/AxiosAjaxUtils.ts
+++ b/packages/utils/src/AxiosAjaxUtils.ts
@@ -2,6 +2,7 @@ import { AjaxError, JsonWebToken } from "@hypernetlabs/objects";
 import axios, { AxiosResponse } from "axios";
 import { injectable } from "inversify";
 import { ResultAsync } from "neverthrow";
+import stream from 'stream';
 
 import { IAjaxUtils, IRequestConfig } from "@utils/IAjaxUtils";
 
@@ -23,6 +24,7 @@ export class AxiosAjaxUtils implements IAjaxUtils {
       | Record<string, unknown>
       | ArrayBuffer
       | ArrayBufferView
+      | stream.Readable 
       | URLSearchParams,
     config?: IRequestConfig,
   ): ResultAsync<T, AjaxError> {
@@ -41,6 +43,7 @@ export class AxiosAjaxUtils implements IAjaxUtils {
       | Record<string, unknown>
       | ArrayBuffer
       | ArrayBufferView
+      | stream.Readable 
       | URLSearchParams,
     config?: IRequestConfig,
   ): ResultAsync<T, AjaxError> {

--- a/packages/utils/src/IAjaxUtils.ts
+++ b/packages/utils/src/IAjaxUtils.ts
@@ -1,6 +1,7 @@
 import { AjaxError, JsonWebToken } from "@hypernetlabs/objects";
 import { AxiosRequestConfig } from "axios";
 import { ResultAsync } from "neverthrow";
+import stream from 'stream';
 
 /**
  * AjaxUtils are just a wrapper around Axios for purposes of testing.
@@ -14,6 +15,7 @@ export interface IAjaxUtils {
       | Record<string, unknown>
       | ArrayBuffer
       | ArrayBufferView
+      | stream.Readable 
       | URLSearchParams,
     config?: IRequestConfig,
   ): ResultAsync<T, AjaxError>;
@@ -24,6 +26,7 @@ export interface IAjaxUtils {
       | Record<string, unknown>
       | ArrayBuffer
       | ArrayBufferView
+      | stream.Readable 
       | URLSearchParams,
     config?: IRequestConfig,
   ): ResultAsync<T, AjaxError>;

--- a/packages/utils/src/IAjaxUtils.ts
+++ b/packages/utils/src/IAjaxUtils.ts
@@ -1,7 +1,7 @@
 import { AjaxError, JsonWebToken } from "@hypernetlabs/objects";
 import { AxiosRequestConfig } from "axios";
 import { ResultAsync } from "neverthrow";
-import stream from 'stream';
+import { Readable } from "stream";
 
 /**
  * AjaxUtils are just a wrapper around Axios for purposes of testing.
@@ -15,7 +15,7 @@ export interface IAjaxUtils {
       | Record<string, unknown>
       | ArrayBuffer
       | ArrayBufferView
-      | stream.Readable 
+      | Readable
       | URLSearchParams,
     config?: IRequestConfig,
   ): ResultAsync<T, AjaxError>;
@@ -26,7 +26,7 @@ export interface IAjaxUtils {
       | Record<string, unknown>
       | ArrayBuffer
       | ArrayBufferView
-      | stream.Readable 
+      | Readable
       | URLSearchParams,
     config?: IRequestConfig,
   ): ResultAsync<T, AjaxError>;


### PR DESCRIPTION
`post<T = any, R = AxiosResponse<T>>(url: string, data?: any, config?: AxiosRequestConfig): Promise<R>;`
` put<T = any, R = AxiosResponse<T>>(url: string, data?: any, config?: AxiosRequestConfig): Promise<R>;`

- Post and Put methods of the axios version that we use take `any` type of data.

- Since I use Readable instance to upload a file to a bucket in the corporate-integration package, we may want it to be type-safe.