### PR TITLE
lock oz contracts version to 4.4.2

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -20,7 +20,7 @@
     "web3": "^1.5.2"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "^4.3.0",
+    "@openzeppelin/contracts": "4.4.2",
     "@openzeppelin/contracts-upgradeable": "^4.3.2",
     "ethers": "^5.5.3",
     "hardhat-contract-sizer": "^2.0.3"


### PR DESCRIPTION
Fixes compilation bug due to 4.4.2 OZ contracts version.