### PR TITLE
removed constructors 

### DIFF
--- a/packages/contracts/contracts/identity/NonFungibleRegistryEnumerableUpgradeable.sol
+++ b/packages/contracts/contracts/identity/NonFungibleRegistryEnumerableUpgradeable.sol
@@ -141,7 +141,7 @@ contract NonFungibleRegistryEnumerableUpgradeable is
     event MerkleRootUpdated(bytes32 merkleRoot, bool frozen); 
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor() initializer {}
+    // constructor() {}
 
     /// @notice initialize is called once on the creation of an upgradable proxy
     /// @dev can only be called once due to the initializer modifier

--- a/packages/contracts/contracts/identity/NonFungibleRegistryUpgradeable.sol
+++ b/packages/contracts/contracts/identity/NonFungibleRegistryUpgradeable.sol
@@ -139,7 +139,7 @@ contract NonFungibleRegistryUpgradeable is
     event MerkleRootUpdated(bytes32 merkleRoot, bool frozen); 
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor() initializer {}
+    // constructor() {}
 
     /// @notice initialize is called once on the creation of an upgradable proxy
     /// @dev can only be called once due to the initializer modifier


### PR DESCRIPTION
Constructors used the "initializer" modifier, which is supposed to be used with the "initialize" method only. So, we cannot call the initialize method with the previous constructors. I commented the constructors out.