### PR TITLE
Quantstamp Report - Adherence to Best Practices

### DIFF
--- a/packages/contracts/contracts/identity/NonFungibleRegistryEnumerableUpgradeable.sol
+++ b/packages/contracts/contracts/identity/NonFungibleRegistryEnumerableUpgradeable.sol
@@ -390,7 +390,7 @@ contract NonFungibleRegistryEnumerableUpgradeable is
         if (identityStakes[tokenId].amount != 0) {
             // send the registration fee to the token burner
             // don't set a registration token you do not control/trust, otherwise, this could be used for re-entrancy attack
-            require(IERC20Upgradeable(identityStakes[tokenId].token).transfer(_msgSender(), identityStakes[tokenId].amount), "NonFungibleRegistry: token tansfer failed.");
+            require(IERC20Upgradeable(identityStakes[tokenId].token).transfer(_msgSender(), identityStakes[tokenId].amount), "NonFungibleRegistry: token transfer failed.");
             delete identityStakes[tokenId];
         }
     }

--- a/packages/contracts/contracts/identity/NonFungibleRegistryUpgradeable.sol
+++ b/packages/contracts/contracts/identity/NonFungibleRegistryUpgradeable.sol
@@ -242,7 +242,7 @@ contract NonFungibleRegistryUpgradeable is
     /// @param _primaryRegistry address to set as the primary registry
     function setPrimaryRegistry(address _primaryRegistry) external {
         require(hasRole(DEFAULT_ADMIN_ROLE, _msgSender()), "NonFungibleRegistry: must be admin.");
-        // allow this feature to be disablled by setting to 0 address
+        // allow this feature to be disabled by setting to 0 address
         if (address(_primaryRegistry) == address(0)) {
             primaryRegistry = address(0); 
         } else {

--- a/packages/contracts/contracts/identity/UpgradeableRegistryFactory.sol
+++ b/packages/contracts/contracts/identity/UpgradeableRegistryFactory.sol
@@ -119,24 +119,23 @@ contract UpgradeableRegistryFactory is AccessControlEnumerable {
     /// @notice setProfileRegistryAddress change the address of the profile registry contract
     /// @dev can only be called by the DEFAULT_ADMIN_ROLE
     /// @param _hypernetProfileRegistry address of ERC721 token to use as profile contract
-    function setProfileRegistryAddress(address _hypernetProfileRegistry) external {
-        require(hasRole(DEFAULT_ADMIN_ROLE, _msgSender()), "RegistryFactory: must have admin role to set parameters");
+    function setProfileRegistryAddress(address _hypernetProfileRegistry) external isAdmin {
+        require(address(_hypernetProfileRegistry) != address(0), "NonFungibleRegistry: Invalid hypernetProfileRegistry address.");
         hypernetProfileRegistry = _hypernetProfileRegistry;
     }
 
     /// @notice setRegistrationToken setter function for configuring which ERC20 token is burned when adding new apps
     /// @dev can only be called by the DEFAULT_ADMIN_ROLE
     /// @param _registrationToken address of ERC20 token burned during registration
-    function setRegistrationToken(address _registrationToken) external {
-        require(hasRole(DEFAULT_ADMIN_ROLE, _msgSender()), "RegistryFactory: must have admin role to set parameters");
+    function setRegistrationToken(address _registrationToken) external isAdmin {
+        require(_registrationToken != address(0), """RegistryFactory: Invalid registrationToken address");
         registrationToken = _registrationToken;
     }
 
     /// @notice setRegistrationFee setter function for configuring how much token is burned when adding new apps
     /// @dev can only be called by the DEFAULT_ADMIN_ROLE
     /// @param _registrationFee burn fee amount
-    function setRegistrationFee(uint256 _registrationFee) external {
-        require(hasRole(DEFAULT_ADMIN_ROLE, _msgSender()), "RegistryFactory: must have admin role to set parameters");
+    function setRegistrationFee(uint256 _registrationFee) external isAdmin {
         require(_registrationFee >= 0, "RegistryFactory: Registration fee must be nonnegative.");
         registrationFee = _registrationFee;
     }
@@ -144,8 +143,7 @@ contract UpgradeableRegistryFactory is AccessControlEnumerable {
     /// @notice setBurnAddress setter function for configuring where tokens are sent when calling createRegistryByToken
     /// @dev can only be called by the DEFAULT_ADMIN_ROLE
     /// @param _burnAddress address where creation fee is to be sent
-    function setBurnAddress(address _burnAddress) external {
-        require(hasRole(DEFAULT_ADMIN_ROLE, _msgSender()), "RegistryFactory: must have admin role to set parameters");
+    function setBurnAddress(address _burnAddress) external isAdmin {
         burnAddress = _burnAddress;
     }
 
@@ -213,5 +211,10 @@ contract UpgradeableRegistryFactory is AccessControlEnumerable {
         // check if there if a profile is required and if so 
         // does the recipient have a non-zero balance. 
         return ((hypernetProfileRegistry == address(0)) || (IERC721Upgradeable(hypernetProfileRegistry).balanceOf(owner) > 0));
+    }
+
+    modifier isAdmin() {
+        require(hasRole(DEFAULT_ADMIN_ROLE, _msgSender()), "RegistryFactory: must have admin role to set parameters");
+        _;
     }
 }

--- a/packages/contracts/contracts/identity/UpgradeableRegistryFactory.sol
+++ b/packages/contracts/contracts/identity/UpgradeableRegistryFactory.sol
@@ -137,7 +137,7 @@ contract UpgradeableRegistryFactory is AccessControlEnumerable {
     /// @param _registrationFee burn fee amount
     function setRegistrationFee(uint256 _registrationFee) external {
         require(hasRole(DEFAULT_ADMIN_ROLE, _msgSender()), "RegistryFactory: must have admin role to set parameters");
-        require(registrationFee >= 0, "RegistryFactory: Registration fee must be nonnegative.");
+        require(_registrationFee >= 0, "RegistryFactory: Registration fee must be nonnegative.");
         registrationFee = _registrationFee;
     }
 


### PR DESCRIPTION
Fixed
- 2. The check in UpgradeableRegistryFactory.sol#140 is unnecessary
- 7. Typo “disablled” in NonFungibleRegistryUpgradeable.sol.
- 8. Typo “tansfer” in NonFungibleRegistryEnumerableUpgradeable.sol.
- 9. In UpgradeableRegistryFactory.sol, require() statements like the one on line 123 are repeated in the nearby functions; consider using a modifier for readability

