### PR TITLE
QSP-2 Changes

### DIFF
--- a/packages/contracts/deployments/polygon-update-4-17-2022/modules/LazyMintModule.sol
+++ b/packages/contracts/deployments/polygon-update-4-17-2022/modules/LazyMintModule.sol
@@ -53,18 +53,26 @@ contract LazyMintModule is Context {
         INfr(registry).register(to, label, registrationData, tokenId);
     }
     
-    function _isValidSignature(address to, string memory label, string memory registrationData, uint256 tokenId, uint256 chainId,  uint256 nonce, bytes memory signature, address registry)
+    function _isValidSignature(address to, string memory label, string memory registrationData, uint256 tokenId, bytes memory signature, address registry)
         internal
         view
         returns (bool)
     {
         // convert the payload to a 32 byte hash
-        bytes32 hash = ECDSA.toEthSignedMessageHash(keccak256(abi.encodePacked(to, label, registrationData, tokenId, chainId, nonce)));
+        bytes32 hash = ECDSA.toEthSignedMessageHash(keccak256(abi.encodePacked(to, label, registrationData, tokenId, _getChainId())));
         
         // check that the signature is from REGISTRAR_ROLE
         address signer = ECDSA.recover(hash, signature);
         require(signer != address(0), "LazyMintModule: Signer cannot be 0 address.");
         return INfr(registry).hasRole(INfr(registry).REGISTRAR_ROLE(), signer);
+    }
+
+     // Get Chain Id from Chain
+    function _getChainId() internal view returns (uint256 id) 
+    {
+        assembly {
+            id := chainid()
+        }
     }
 }
 

--- a/packages/contracts/test/upgradeable-registry-enumerable-test.js
+++ b/packages/contracts/test/upgradeable-registry-enumerable-test.js
@@ -1,6 +1,6 @@
 const { expectRevert } = require("@openzeppelin/test-helpers");
 const { expect } = require("chai");
-const { ethers, upgrades } = require("hardhat");
+const { ethers, upgrades, hre } = require("hardhat");
 const { MerkleTree } = require('merkletreejs');
 const keccak256 = require('keccak256');
 const tokens = require('./tokens.json');
@@ -661,11 +661,15 @@ it("Test lazy minting.", async function () {
     let registrationData = "00000000000000030000000061672e7d";
     let tokenId = 007;
 
+    // Get current chain id:
+
+    let chainId = hre.network.config.chainId;
+    
     // hash the data
     var hash = ethers.utils
       .solidityKeccak256(
-        ["address", "string", "string", "uint256"],
-        [addr1.address, label, registrationData, tokenId],
+        ["address", "string", "string", "uint256", "uint256"],
+        [addr1.address, label, registrationData, tokenId, chainId],
       )
       .toString("hex");
 

--- a/packages/contracts/test/upgradeable-registry-test.js
+++ b/packages/contracts/test/upgradeable-registry-test.js
@@ -1,6 +1,6 @@
 const { BN, expectRevert } = require("@openzeppelin/test-helpers");
 const { expect } = require("chai");
-const { ethers, upgrades } = require("hardhat");
+const { ethers, upgrades, hre } = require("hardhat");
 const { MerkleTree } = require("merkletreejs");
 const keccak256 = require("keccak256");
 const tokens = require("./tokens.json");
@@ -678,11 +678,12 @@ it("Test batch minting function.", async function () {
     let registrationData = "00000000000000030000000061672e7d";
     let tokenId = 1;
 
+    let chainId = hre.network.config.chainId;
     // hash the data
     var hash = ethers.utils
       .solidityKeccak256(
-        ["address", "string", "string", "uint256"],
-        [addr1.address, label, registrationData, tokenId],
+        ["address", "string", "string", "uint256", "uint256"],
+        [addr1.address, label, registrationData, tokenId, chainId],
       )
       .toString("hex");
 

--- a/packages/governance-sdk/src/ILazyMintModuleContract.ts
+++ b/packages/governance-sdk/src/ILazyMintModuleContract.ts
@@ -14,8 +14,6 @@ export interface ILazyMintModuleContract {
     registryAddress: EthereumContractAddress,
     signature: Signature,
     tokenId: RegistryTokenId,
-    chainId: Number,
-    nonce: Number,
     ownerAddress: EthereumAccountAddress,
     registrationData: string,
     overrides?: ContractOverrides,

--- a/packages/governance-sdk/src/LazyMintModuleContract.ts
+++ b/packages/governance-sdk/src/LazyMintModuleContract.ts
@@ -33,8 +33,6 @@ export class LazyMintModuleContract implements ILazyMintModuleContract {
     registryAddress: EthereumContractAddress,
     signature: Signature,
     tokenId: RegistryTokenId,
-    chainId: Number,
-    nonce: Number,
     ownerAddress: EthereumAccountAddress,
     registrationData: string,
     overrides: ContractOverrides | null = null,
@@ -51,15 +49,13 @@ export class LazyMintModuleContract implements ILazyMintModuleContract {
             label,
             registrationData,
             tokenId,
-            chainId,
-            nonce,
             signature,
             registryAddress,
             { ...gasFee, ...overrides },
           ) as Promise<ethers.providers.TransactionResponse>,
           (e) => {
             return new LazyMintModuleContractError(
-              "Unable to call LazyMintModuleContract batchRegister()",
+              "Unable to call LazyMintModuleContract lazyRegister()",
               e,
             );
           },

--- a/packages/hypernet-core/src/implementations/HypernetCore.ts
+++ b/packages/hypernet-core/src/implementations/HypernetCore.ts
@@ -2128,8 +2128,6 @@ export class HypernetCore implements IHypernetCore {
     submitLazyMintSignature: (
       registryName: RegistryName,
       tokenId: RegistryTokenId,
-      chainId: Number,
-      nonce: Number,
       ownerAddress: EthereumAccountAddress,
       registrationData: string,
     ): ResultAsync<
@@ -2144,8 +2142,6 @@ export class HypernetCore implements IHypernetCore {
       return this.registryService.submitLazyMintSignature(
         registryName,
         tokenId,
-        chainId,
-        nonce,
         ownerAddress,
         registrationData,
       );

--- a/packages/hypernet-core/src/implementations/business/RegistryService.ts
+++ b/packages/hypernet-core/src/implementations/business/RegistryService.ts
@@ -327,8 +327,6 @@ export class RegistryService implements IRegistryService {
   public submitLazyMintSignature(
     registryName: RegistryName,
     tokenId: RegistryTokenId,
-    chainId: Number,
-    nonce: Number,
     ownerAddress: EthereumAccountAddress,
     registrationData: string,
   ): ResultAsync<
@@ -343,8 +341,6 @@ export class RegistryService implements IRegistryService {
     return this.registryRepository.submitLazyMintSignature(
       registryName,
       tokenId,
-      chainId,
-      nonce,
       ownerAddress,
       registrationData,
     );

--- a/packages/hypernet-core/src/implementations/data/RegistryRepository.ts
+++ b/packages/hypernet-core/src/implementations/data/RegistryRepository.ts
@@ -1401,8 +1401,6 @@ export class RegistryRepository implements IRegistryRepository {
   public submitLazyMintSignature(
     registryName: RegistryName,
     tokenId: RegistryTokenId,
-    chainId: Number,
-    nonce: Number,
     ownerAddress: EthereumAccountAddress,
     registrationData: string,
   ): ResultAsync<
@@ -1439,12 +1437,15 @@ export class RegistryRepository implements IRegistryRepository {
           ),
         );
       }
-
+      if (this.provider == null) {
+        throw new Error("No provider available!");
+      }
+      let chainId = this.provider.getNetwork().then(function(network) { return network.chainId});
       // hash the data
       const hash = ethers.utils
         .solidityKeccak256(
-          ["address", "string", "string", "uint256"],
-          [ownerAddress, "", registrationData, tokenId],
+          ["address", "string", "string", "uint256", "uint256"],
+          [ownerAddress, "", registrationData, tokenId, chainId],
         )
         .toString();
 
@@ -1466,8 +1467,6 @@ export class RegistryRepository implements IRegistryRepository {
                 registry.address,
                 signature,
                 tokenId,
-                chainId,
-                nonce,
                 ownerAddress,
                 registrationData,
                 signerAddress,
@@ -1553,8 +1552,6 @@ export class RegistryRepository implements IRegistryRepository {
                 lazyMintingSignature.registryAddress,
                 lazyMintingSignature.mintingSignature,
                 lazyMintingSignature.tokenId,
-                lazyMintingSignature.chainId,
-                lazyMintingSignature.nonce,
                 lazyMintingSignature.ownerAccountAddress,
                 lazyMintingSignature.registrationData,
               );

--- a/packages/hypernet-core/src/interfaces/business/IRegistryService.ts
+++ b/packages/hypernet-core/src/interfaces/business/IRegistryService.ts
@@ -214,8 +214,6 @@ export interface IRegistryService {
   submitLazyMintSignature(
     registryName: RegistryName,
     tokenId: RegistryTokenId,
-    chainId: Number,
-    nonce: Number,
     ownerAddress: EthereumAccountAddress,
     registrationData: string,
   ): ResultAsync<

--- a/packages/hypernet-core/src/interfaces/data/IRegistryRepository.ts
+++ b/packages/hypernet-core/src/interfaces/data/IRegistryRepository.ts
@@ -221,8 +221,6 @@ export interface IRegistryRepository {
   submitLazyMintSignature(
     registryName: RegistryName,
     tokenId: RegistryTokenId,
-    chainId: Number,
-    nonce: Number,
     ownerAddress: EthereumAccountAddress,
     registrationData: string,
   ): ResultAsync<

--- a/packages/iframe/src/implementations/api/CoreListener.ts
+++ b/packages/iframe/src/implementations/api/CoreListener.ts
@@ -654,9 +654,7 @@ export class CoreListener extends ChildProxy implements ICoreListener {
       submitLazyMintSignature: (
         data: IIFrameCallData<{
           registryName: RegistryName;
-          tokenId: RegistryTokenId;
-          chainId: Number,
-          nonce: Number, 
+          tokenId: RegistryTokenId; 
           ownerAddress: EthereumAccountAddress;
           registrationData: string;
         }>,
@@ -665,8 +663,6 @@ export class CoreListener extends ChildProxy implements ICoreListener {
           return this.core.registries.submitLazyMintSignature(
             data.data.registryName,
             data.data.tokenId,
-            data.data.chainId,
-            data.data.nonce,
             data.data.ownerAddress,
             data.data.registrationData,
           );

--- a/packages/objects/src/LazyMintingSignature.ts
+++ b/packages/objects/src/LazyMintingSignature.ts
@@ -8,8 +8,6 @@ export class LazyMintingSignature {
     public registryAddress: EthereumContractAddress,
     public mintingSignature: Signature,
     public tokenId: RegistryTokenId,
-    public chainId: Number,
-    public nonce: Number,
     public ownerAccountAddress: EthereumAccountAddress,
     public registrationData: string,
     public registrarAddress: EthereumAccountAddress,

--- a/packages/objects/src/interfaces/IHypernetRegistries.ts
+++ b/packages/objects/src/interfaces/IHypernetRegistries.ts
@@ -267,8 +267,6 @@ export interface IHypernetRegistries {
   submitLazyMintSignature(
     registryName: RegistryName,
     tokenId: RegistryTokenId,
-    chainId: Number,
-    nonce: Number,
     ownerAddress: EthereumAccountAddress,
     registrationData: string,
   ): ResultAsync<

--- a/packages/web-integration/src/implementations/proxy/HypernetIFrameProxy.ts
+++ b/packages/web-integration/src/implementations/proxy/HypernetIFrameProxy.ts
@@ -1276,8 +1276,6 @@ export default class HypernetIFrameProxy
     submitLazyMintSignature: (
       registryName: string,
       tokenId: RegistryTokenId,
-      chainId: Number,
-      nonce: Number,
       ownerAddress: EthereumAccountAddress,
       registrationData: string,
     ): ResultAsync<
@@ -1293,8 +1291,6 @@ export default class HypernetIFrameProxy
       return this._createCall("submitLazyMintSignature", {
         registryName,
         tokenId,
-        chainId,
-        nonce,
         ownerAddress,
         registrationData,
       });

--- a/packages/web-ui/src/widgets/CreateIdentityWidget/CreateIdentityWidget.tsx
+++ b/packages/web-ui/src/widgets/CreateIdentityWidget/CreateIdentityWidget.tsx
@@ -74,9 +74,7 @@ const CreateIdentityWidget: React.FC<ICreateIdentityWidget> = ({
   const handlLazyMintIdentity = ({
     recipientAddress,
     tokenUri,
-    tokenId,
-    chainId,
-    nonce
+    tokenId
   }: ICreateIdentityFormValues) => {
     setLoading(true);
 
@@ -84,8 +82,6 @@ const CreateIdentityWidget: React.FC<ICreateIdentityWidget> = ({
       .submitLazyMintSignature(
         RegistryName(registryName),
         RegistryTokenId(tokenId),
-        Number(chainId),
-        Number(nonce),
         EthereumAccountAddress(recipientAddress),
         tokenUri,
       )


### PR DESCRIPTION
Made changes to lookup-chain ID inside the contract to verify the signature to prevent replay on another chain. Nonce and other mechanism are not needed as it can not be replayed on same chain by design. If the label is already registered, it will error out. Made changes in other interfaces and calling applications to call with putting chain-id in initial encoding.