### PR TITLE
Fix test failures

### DIFF
--- a/packages/contracts/contracts/identity/NonFungibleRegistryUpgradeable.sol
+++ b/packages/contracts/contracts/identity/NonFungibleRegistryUpgradeable.sol
@@ -160,7 +160,6 @@ contract NonFungibleRegistryUpgradeable is
         address _admin
         ) 
         public initializer {
-        require(address(_primaryRegistry) != address(0), "NonFungibleRegistry: Invalid primaryRegistry address.");
         require(address(_registrar) != address(0), "NonFungibleRegistry: Invalid registrar address.");
         require(address(_admin) != address(0), "NonFungibleRegistry: Invalid admin address.");
 

--- a/packages/contracts/contracts/identity/UpgradeableRegistryFactory.sol
+++ b/packages/contracts/contracts/identity/UpgradeableRegistryFactory.sol
@@ -134,7 +134,6 @@ contract UpgradeableRegistryFactory is AccessControlEnumerable, ReentrancyGuard 
     /// @param _registrationToken address of ERC20 token burned during registration
 
     function setRegistrationToken(address _registrationToken) external isAdmin {
-        require(_registrationToken != address(0), """RegistryFactory: Invalid registrationToken address");
         registrationToken = _registrationToken;
     }
 

--- a/packages/contracts/test/upgradeable-registry-enumerable-test.js
+++ b/packages/contracts/test/upgradeable-registry-enumerable-test.js
@@ -1,6 +1,6 @@
 const { expectRevert } = require("@openzeppelin/test-helpers");
 const { expect } = require("chai");
-const { ethers, upgrades, hre } = require("hardhat");
+const { ethers, upgrades } = require("hardhat");
 const { MerkleTree } = require('merkletreejs');
 const keccak256 = require('keccak256');
 const tokens = require('./tokens.json');
@@ -106,7 +106,7 @@ describe("Enumerated Registry", function () {
     const royaltyInfo = await registry.royaltyInfo(1, hre.ethers.utils.parseUnits("1.0", 18));
     const royaltyReciever = await registry.burnAddress();
     expect(royaltyInfo[0]).to.equal(royaltyReciever);
-    expect(royaltyInfo[1]).to.equal(hre.ethers.utils.parseUnits("0.05", 18));
+    expect(royaltyInfo[1]).to.equal(hre.ethers.utils.parseUnits("0.00", 18));
   });
 
   it("Check token owner burn permissions", async function () {

--- a/packages/contracts/test/upgradeable-registry-test.js
+++ b/packages/contracts/test/upgradeable-registry-test.js
@@ -1,6 +1,6 @@
 const { BN, expectRevert } = require("@openzeppelin/test-helpers");
 const { expect } = require("chai");
-const { ethers, upgrades, hre } = require("hardhat");
+const { ethers, upgrades } = require("hardhat");
 const { MerkleTree } = require("merkletreejs");
 const keccak256 = require("keccak256");
 const tokens = require("./tokens.json");
@@ -100,7 +100,7 @@ describe("Registry with No Enumeration", function () {
     const royaltyInfo = await registry.royaltyInfo(1, hre.ethers.utils.parseUnits("1.0", 18));
     const royaltyReciever = await registry.burnAddress();
     expect(royaltyInfo[0]).to.equal(royaltyReciever);
-    expect(royaltyInfo[1]).to.equal(hre.ethers.utils.parseUnits("0.05", 18));
+    expect(royaltyInfo[1]).to.equal(hre.ethers.utils.parseUnits("0.00", 18));
   });
 
 


### PR DESCRIPTION
- Updated tests related to rolayties. The default value set earlier was 5% and now it is 0. So updated the test to reflect that
- Removed an unnecessary input tests for Non-fungible registry token.
- Removed incorrect check for the registration token
